### PR TITLE
print対象の修正

### DIFF
--- a/notebooks/Transfer_Learning_ja.ipynb
+++ b/notebooks/Transfer_Learning_ja.ipynb
@@ -293,13 +293,15 @@
      "output_type": "stream",
      "text": [
       "<_OptionsDataset shapes: ((None, None, 3), ()), types: (tf.uint8, tf.int64)>\n",
+      "<_OptionsDataset shapes: ((None, None, 3), ()), types: (tf.uint8, tf.int64)>\n",
       "<_OptionsDataset shapes: ((None, None, 3), ()), types: (tf.uint8, tf.int64)>\n"
      ]
     }
    ],
    "source": [
     "print(raw_train)\n",
-    "print(raw_train)"
+    "print(raw_validation)\n",
+    "print(raw_test)"
    ]
   },
   {


### PR DESCRIPTION
transfer_learning.ipynbでprint対象に差異がありましたので報告いたします。  
その後の転移学習自体に影響はありません。