### PR TITLE
Downgrade numpy to 1.16.2 to avoid ValueError

### DIFF
--- a/notebooks/Basic_Text_Classification_ja.ipynb
+++ b/notebooks/Basic_Text_Classification_ja.ipynb
@@ -1,1277 +1,1129 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "YGjgJiN2xrOZ"
-   },
-   "source": [
-    "##### Copyright 2018 The TensorFlow Authors.\n",
-    "\n",
-    "##### Modifications Copyright 2019 Tomoaki Masuda."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "w2jnRPhYxrOb"
-   },
-   "outputs": [],
-   "source": [
-    "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-    "# you may not use this file except in compliance with the License.\n",
-    "# You may obtain a copy of the License at\n",
-    "#\n",
-    "# https://www.apache.org/licenses/LICENSE-2.0\n",
-    "#\n",
-    "# Unless required by applicable law or agreed to in writing, software\n",
-    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-    "# See the License for the specific language governing permissions and\n",
-    "# limitations under the License."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "YI1rVCDzxrOe"
-   },
-   "outputs": [],
-   "source": [
-    "#@title MIT License\n",
-    "#\n",
-    "# Copyright (c) 2017 François Chollet\n",
-    "#\n",
-    "# Permission is hereby granted, free of charge, to any person obtaining a\n",
-    "# copy of this software and associated documentation files (the \"Software\"),\n",
-    "# to deal in the Software without restriction, including without limitation\n",
-    "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
-    "# and/or sell copies of the Software, and to permit persons to whom the\n",
-    "# Software is furnished to do so, subject to the following conditions:\n",
-    "#\n",
-    "# The above copyright notice and this permission notice shall be included in\n",
-    "# all copies or substantial portions of the Software.\n",
-    "#\n",
-    "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
-    "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
-    "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
-    "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
-    "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
-    "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
-    "# DEALINGS IN THE SOFTWARE."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "このノートブックは、以下のノートブックを元に日本語訳、一部章立ての再構成、加筆を行いました。https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_text_classification.ipynb"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "GBj2ktQDxrOh"
-   },
-   "source": [
-    "\n",
-    "# 映画情報サイトにあるレビューを識別する\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "oKQ5YSCexrOj"
-   },
-   "source": [
-    "\n",
-    "このノートブックは、映画レビューの文章を、*ポジティブな評価*か*ネガティブな評価*かの二種類に分類します。これは、二項分類や二クラス分類と呼ばれ、重要かつ幅広く使える機械学習のタスクのひとつです。 \n",
-    "\n",
-    " [Internet Movie Database](https://www.imdb.com/)から5万の映画レビュー文章を集めたデータセットである、[IMDBデータセット](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/imdb)を使います。これは学習用2万5千レビューとテスト用2万5千レビューに分けられます。学習セットとテストセットはポジティブ、ネガティブ同数のレビューが含まれます（balanced）。 \n",
-    "\n",
-    "このノートブックはTensorFlowでモデルを構築し学習するための高レベルAPI [tf.keras](https://www.tensorflow.org/guide/keras)を使います。 `tf.keras`を使用したより高度なテキスト分類チュートリアルは、 [MLCCテキスト分類ガイド](https://developers.google.com/machine-learning/guides/text-classification/)を参照してください。 \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "## A. 環境を準備する\n",
-    "\n",
-    "必要なライブラリのインストール、インポートを行います。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
+      "name": "映画情報サイトにあるレビューを識別する（その1）",
+      "version": "0.3.2",
+      "provenance": []
     },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 1731,
-     "status": "ok",
-     "timestamp": 1553304386738,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
     },
-    "id": "5iguN9LGxrOk",
-    "outputId": "50b1da27-844e-41cc-b736-c56dd96427bf"
-   },
-   "outputs": [
+    "accelerator": "GPU"
+  },
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1.13.1\n"
-     ]
-    }
-   ],
-   "source": [
-    "import tensorflow as tf\n",
-    "from tensorflow import keras\n",
-    "\n",
-    "import numpy as np\n",
-    "\n",
-    "print(tf.__version__)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "## B. データセットを準備する\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "lXI8AdMuxrOm"
-   },
-   "source": [
-    "### 1. IMDBデータセットをダウンロードする\n",
-    "\n",
-    " IMDBデータセットはTensorFlowに同梱されています。レビュー（単語の並び）が整数の並びに変換されるよう、すでに前処理されています。各整数は辞書内の特定の単語を表します。 \n",
-    "\n",
-    "次のコードで、IMDBデータセットをダウンロードします（すでにダウンロード済みの場合はキャッシュコピーを使用します）。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 41820,
-     "status": "ok",
-     "timestamp": 1553304432503,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "_vY-ROKbxrOn",
-    "outputId": "ced05649-25e0-4a4f-cf8d-b48a662626eb"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/imdb.npz\n",
-      "17465344/17464789 [==============================] - 0s 0us/step\n",
-      "17473536/17464789 [==============================] - 1s 0us/step\n"
-     ]
-    }
-   ],
-   "source": [
-    "imdb = keras.datasets.imdb\n",
-    "\n",
-    "(train_data, train_labels), (test_data, test_labels) = imdb.load_data(num_words=10000)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "It6WhG12xrOq"
-   },
-   "source": [
-    "\n",
-    "引数`num_words=10000`で、学習データセット中、最も頻繁に出現する上位1万語のみ保持するよう指定します。データのサイズが大きくなり過ぎないよう、あまり出てこない単語は破棄されます。 \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "AvRq7MeQxrOr"
-   },
-   "source": [
-    "\n",
-    "### 2. データセットの中身を見てみる\n",
-    "\n",
-    "少し時間をかけて、データのフォーマットを理解しましょう。データセットは前処理されています。各例は、映画レビューの単語を表す整数の並び（配列）です。各ラベルは0または1の整数値です。0は否定的なレビュー、1は肯定的なレビューを表します。 \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "VaTgE3KyKMmk"
-   },
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 657,
-     "status": "ok",
-     "timestamp": 1553304445270,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "7Qu3dfyDxrOt",
-    "outputId": "f795bebd-762f-4958-c6fa-5ab571beb869"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training entries: 25000, labels: 25000\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\"Training entries: {}, labels: {}\".format(len(train_data), len(train_labels)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "d504bc4UxrOx"
-   },
-   "source": [
-    "\n",
-    "レビューのテキストは整数に変換され、各整数は辞書内にある単語を表します。最初のレビューは次のようになります。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 54
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 762,
-     "status": "ok",
-     "timestamp": 1553304448479,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "XcykwkYBxrOy",
-    "outputId": "392dea32-02d6-431a-a97f-289d4d0515fc"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1, 14, 22, 16, 43, 530, 973, 1622, 1385, 65, 458, 4468, 66, 3941, 4, 173, 36, 256, 5, 25, 100, 43, 838, 112, 50, 670, 2, 9, 35, 480, 284, 5, 150, 4, 172, 112, 167, 2, 336, 385, 39, 4, 172, 4536, 1111, 17, 546, 38, 13, 447, 4, 192, 50, 16, 6, 147, 2025, 19, 14, 22, 4, 1920, 4613, 469, 4, 22, 71, 87, 12, 16, 43, 530, 38, 76, 15, 13, 1247, 4, 22, 17, 515, 17, 12, 16, 626, 18, 2, 5, 62, 386, 12, 8, 316, 8, 106, 5, 4, 2223, 5244, 16, 480, 66, 3785, 33, 4, 130, 12, 16, 38, 619, 5, 25, 124, 51, 36, 135, 48, 25, 1415, 33, 6, 22, 12, 215, 28, 77, 52, 5, 14, 407, 16, 82, 2, 8, 4, 107, 117, 5952, 15, 256, 4, 2, 7, 3766, 5, 723, 36, 71, 43, 530, 476, 26, 400, 317, 46, 7, 4, 2, 1029, 13, 104, 88, 4, 381, 15, 297, 98, 32, 2071, 56, 26, 141, 6, 194, 7486, 18, 4, 226, 22, 21, 134, 476, 26, 480, 5, 144, 30, 5535, 18, 51, 36, 28, 224, 92, 25, 104, 4, 226, 65, 16, 38, 1334, 88, 12, 16, 283, 5, 16, 4472, 113, 103, 32, 15, 16, 5345, 19, 178, 32]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(train_data[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "a4Mls2KHxrO3"
-   },
-   "source": [
-    "\n",
-    "映画のレビュー文は、それぞれ長さが異なります。以下のコードで、最初のレビューと2番目のレビューの単語数を確認してみましょう。一般に、ニューラルネットワークへの入力は同じ長さである必要があります。後でこの問題を解決しましょう。\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 998,
-     "status": "ok",
-     "timestamp": 1553304451860,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "5azJ69ToxrO4",
-    "outputId": "204d3c7e-28b0-4ee2-e462-20b149e5756b"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(218, 189)"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "YGjgJiN2xrOZ"
+      },
+      "source": [
+        "##### Copyright 2018 The TensorFlow Authors.\n",
+        "\n",
+        "##### Modifications Copyright 2019 Tomoaki Masuda."
       ]
-     },
-     "execution_count": 5,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(train_data[0]), len(train_data[1])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "Ra11Xz_nxrO5"
-   },
-   "source": [
-    "\n",
-    "### 3. 整数を単語に戻す\n",
-    "\n",
-    "整数をテキストに変換して戻す方法を知っておくと便利です。ここでは、整数から文字列への対応づけを持つ辞書オブジェクトへ、問い合わせをするためのヘルパー関数を作ります。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 68
     },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 1932,
-     "status": "ok",
-     "timestamp": 1553304457664,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "ByGieyTrxrO6",
-    "outputId": "5771117a-f469-48c1-cae7-2a88033cafa6"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/imdb_word_index.json\n",
-      "1646592/1641221 [==============================] - 0s 0us/step\n",
-      "1654784/1641221 [==============================] - 0s 0us/step\n"
-     ]
-    }
-   ],
-   "source": [
-    "# A dictionary mapping words to an integer index\n",
-    "word_index = imdb.get_word_index()\n",
-    "\n",
-    "# The first indices are reserved\n",
-    "word_index = {k:(v+3) for k,v in word_index.items()} \n",
-    "word_index[\"<PAD>\"] = 0\n",
-    "word_index[\"<START>\"] = 1\n",
-    "word_index[\"<UNK>\"] = 2  # unknown\n",
-    "word_index[\"<UNUSED>\"] = 3\n",
-    "\n",
-    "reverse_word_index = dict([(value, key) for (key, value) in word_index.items()])\n",
-    "\n",
-    "def decode_review(text):\n",
-    "    return ' '.join([reverse_word_index.get(i, '?') for i in text])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "9y8HH1AoxrO8"
-   },
-   "source": [
-    "\n",
-    "これで`decode_review`関数を使って最初のレビューのテキストを表示することができます。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 54
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "w2jnRPhYxrOb",
+        "colab": {}
+      },
+      "source": [
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "# you may not use this file except in compliance with the License.\n",
+        "# You may obtain a copy of the License at\n",
+        "#\n",
+        "# https://www.apache.org/licenses/LICENSE-2.0\n",
+        "#\n",
+        "# Unless required by applicable law or agreed to in writing, software\n",
+        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+        "# See the License for the specific language governing permissions and\n",
+        "# limitations under the License."
+      ],
+      "execution_count": 0,
+      "outputs": []
     },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 890,
-     "status": "ok",
-     "timestamp": 1553304459540,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "f-KYJS3axrO9",
-    "outputId": "f5d5eccc-11e3-4603-86e3-d6897461efa8"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "u\"<START> this film was just brilliant casting location scenery story direction everyone's really suited the part they played and you could just imagine being there robert <UNK> is an amazing actor and now the same being director <UNK> father came from the same scottish island as myself so i loved the fact there was a real connection with this film the witty remarks throughout the film were great it was just brilliant so much that i bought the film as soon as it was released for <UNK> and would recommend it to everyone to watch and the fly fishing was amazing really cried at the end it was so sad and you know what they say if you cry at a film it must have been good and this definitely was also <UNK> to the two little boy's that played the <UNK> of norman and paul they were just brilliant children are often left out of the <UNK> list i think because the stars that play them all grown up are such a big profile for the whole film but these children are amazing and should be praised for what they have done don't you think the whole story was so lovely because it was true and was someone's life after all that was shared with us all\""
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "YI1rVCDzxrOe",
+        "colab": {}
+      },
+      "source": [
+        "#@title MIT License\n",
+        "#\n",
+        "# Copyright (c) 2017 François Chollet\n",
+        "#\n",
+        "# Permission is hereby granted, free of charge, to any person obtaining a\n",
+        "# copy of this software and associated documentation files (the \"Software\"),\n",
+        "# to deal in the Software without restriction, including without limitation\n",
+        "# the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
+        "# and/or sell copies of the Software, and to permit persons to whom the\n",
+        "# Software is furnished to do so, subject to the following conditions:\n",
+        "#\n",
+        "# The above copyright notice and this permission notice shall be included in\n",
+        "# all copies or substantial portions of the Software.\n",
+        "#\n",
+        "# THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n",
+        "# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n",
+        "# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL\n",
+        "# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n",
+        "# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n",
+        "# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER\n",
+        "# DEALINGS IN THE SOFTWARE."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "96sUuJdYp6CU",
+        "colab_type": "text"
+      },
+      "source": [
+        "このノートブックは、以下のノートブックを元に日本語訳、一部章立ての再構成、加筆を行いました。https://github.com/tensorflow/docs/blob/master/site/en/tutorials/keras/basic_text_classification.ipynb"
       ]
-     },
-     "execution_count": 7,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "decode_review(train_data[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "GVyXzVW7xrO_"
-   },
-   "source": [
-    "\n",
-    "## C. データセットを前処理する\n",
-    "\n",
-    "レビュー（整数の配列）は、ニューラルネットワークへ入力する前にテンソルに変換します。変換には、いくつか方法があります。 \n",
-    "\n",
-    "- ワンホットエンコーディングと同様、配列を単語の出現を示す0と1のベクトルに変換します。たとえば、シーケンス `[3、5]` は、1であるインデックス3と5を除いて、すべて0の1万次元ベクトルになります。次に、これをネットワークの最初の層、つまり、浮動小数点のベクトルデータを処理できる全結合層にします。ただし、この方法では大量のメモリが必要です。 `num_words * num_reviews`の形をもつ行列を保持するからです。 \n",
-    "- 代わりに、すべて同じ長さになるように配列をパディングしてから、`max_length * num_reviews`の形をもつ整数テンソルを作成することもできます。この形状を処理できるembedding層をネットワークの最初の層として使います。\n",
-    "\n",
-    "このチュートリアルでは、後者を使います。 \n",
-    "\n",
-    "入力の映画レビューを同じ長さである必要があるので、 [pad_sequences](https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/sequence/pad_sequences)関数を使い、長さを標準化します。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "vLU5uhCyxrPA"
-   },
-   "outputs": [],
-   "source": [
-    "train_data = keras.preprocessing.sequence.pad_sequences(train_data,\n",
-    "                                                        value=word_index[\"<PAD>\"],\n",
-    "                                                        padding='post',\n",
-    "                                                        maxlen=256)\n",
-    "\n",
-    "test_data = keras.preprocessing.sequence.pad_sequences(test_data,\n",
-    "                                                       value=word_index[\"<PAD>\"],\n",
-    "                                                       padding='post',\n",
-    "                                                       maxlen=256)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "nejMKis6xrPD"
-   },
-   "source": [
-    "\n",
-    "例の長さを見てみましょう。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
     },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 780,
-     "status": "ok",
-     "timestamp": 1553304466295,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "BB-683yQxrPE",
-    "outputId": "27a2c28f-1e8e-4a67-9d7e-c5ecc51ac0c9"
-   },
-   "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "(256, 256)"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "GBj2ktQDxrOh"
+      },
+      "source": [
+        "\n",
+        "# 映画情報サイトにあるレビューを識別する\n"
       ]
-     },
-     "execution_count": 9,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "len(train_data[0]), len(train_data[1])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "WGTQ2XeJxrPJ"
-   },
-   "source": [
-    "\n",
-    "そして、（今はパディングされた）最初のレビューを調べます。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 340
     },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 956,
-     "status": "ok",
-     "timestamp": 1553304468448,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "mzyoemxxxrPJ",
-    "outputId": "374478d0-d229-4e4d-9892-2865c5c70b27"
-   },
-   "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[   1   14   22   16   43  530  973 1622 1385   65  458 4468   66 3941\n",
-      "    4  173   36  256    5   25  100   43  838  112   50  670    2    9\n",
-      "   35  480  284    5  150    4  172  112  167    2  336  385   39    4\n",
-      "  172 4536 1111   17  546   38   13  447    4  192   50   16    6  147\n",
-      " 2025   19   14   22    4 1920 4613  469    4   22   71   87   12   16\n",
-      "   43  530   38   76   15   13 1247    4   22   17  515   17   12   16\n",
-      "  626   18    2    5   62  386   12    8  316    8  106    5    4 2223\n",
-      " 5244   16  480   66 3785   33    4  130   12   16   38  619    5   25\n",
-      "  124   51   36  135   48   25 1415   33    6   22   12  215   28   77\n",
-      "   52    5   14  407   16   82    2    8    4  107  117 5952   15  256\n",
-      "    4    2    7 3766    5  723   36   71   43  530  476   26  400  317\n",
-      "   46    7    4    2 1029   13  104   88    4  381   15  297   98   32\n",
-      " 2071   56   26  141    6  194 7486   18    4  226   22   21  134  476\n",
-      "   26  480    5  144   30 5535   18   51   36   28  224   92   25  104\n",
-      "    4  226   65   16   38 1334   88   12   16  283    5   16 4472  113\n",
-      "  103   32   15   16 5345   19  178   32    0    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
-      "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
-      "    0    0    0    0]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(train_data[0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "TpUMYWyHxrPO"
-   },
-   "source": [
-    "\n",
-    "## D. モデルを作成する\n",
-    "\n",
-    "ニューラルネットワークは、レイヤを連ねる、または重ねて作ります。構造（アーキテクチャ）を決める、2つ重要なポイントがあります。\n",
-    "\n",
-    "- モデルにいくつのレイヤを使うか？\n",
-    "- 各層にいくつの*ノード*を使うか？ \n",
-    "\n",
-    "この例では、入力は単語インデックスの配列です。出力される予測ラベルは0か1のいずれかです。この課題を解くモデルを作りましょう。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 343
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 676,
-     "status": "ok",
-     "timestamp": 1553304475329,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "7qtgBGp_xrPO",
-    "outputId": "220f1554-696c-4daa-d3d4-67ba42498615"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Colocations handled automatically by placer.\n",
-      "_________________________________________________________________\n",
-      "Layer (type)                 Output Shape              Param #   \n",
-      "=================================================================\n",
-      "embedding (Embedding)        (None, None, 16)          160000    \n",
-      "_________________________________________________________________\n",
-      "global_average_pooling1d (Gl (None, 16)                0         \n",
-      "_________________________________________________________________\n",
-      "dense (Dense)                (None, 16)                272       \n",
-      "_________________________________________________________________\n",
-      "dense_1 (Dense)              (None, 1)                 17        \n",
-      "=================================================================\n",
-      "Total params: 160,289\n",
-      "Trainable params: 160,289\n",
-      "Non-trainable params: 0\n",
-      "_________________________________________________________________\n"
-     ]
-    }
-   ],
-   "source": [
-    "# input shape is the vocabulary count used for the movie reviews (10,000 words)\n",
-    "vocab_size = 10000\n",
-    "\n",
-    "model = keras.Sequential()\n",
-    "model.add(keras.layers.Embedding(vocab_size, 16))\n",
-    "model.add(keras.layers.GlobalAveragePooling1D())\n",
-    "model.add(keras.layers.Dense(16, activation=tf.nn.relu))\n",
-    "model.add(keras.layers.Dense(1, activation=tf.nn.sigmoid))\n",
-    "\n",
-    "model.summary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "pEJ5VVuRxrPU"
-   },
-   "source": [
-    "\n",
-    "これらの層を順番に積み重ねて分類器を作ります。\n",
-    "\n",
-    "1. 最初の層は`Embedding`層です。この層は整数で表された単語を取り、各単語のインデックスに対応した単語の埋め込みベクトル（または、単語の分散表現）を返します。これらの埋め込みベクトルも、モデルの学習が進むのと同時に、学習が進みます。ベクトルは出力配列に次元を追加します。結果得られる次元は`(batch, sequence, embedding)`です。 \n",
-    "1. 次に、 `GlobalAveragePooling1D`レイヤは、シーケンスにある単語毎の埋め込みベクトルの各次元を、単語横断で平均をとることで、各レビューに対応する固定長出力ベクトルを返します。これで、モデルは可変長の入力を固定長として扱えるようになります。平均を取るのは、考えうる限り一番簡単な方法でしょう。 \n",
-    "1. この固定長出力ベクトルは、16個のノードを持つ全結合層（ `Dense` ）を通り、処理されます。 \n",
-    "1. 最終層の単一の出力ノードとは、全結合で接続されます。 `sigmoid`を活性化関数として使い、出力ノードの値は0から1の間の浮動小数点数(float型)として、確率、または確信度を表します。 \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "FIYsvn-RxrPV"
-   },
-   "source": [
-    "\n",
-    "### 1. ノード（隠れユニット）\n",
-    "\n",
-    "\n",
-    "上記のモデルには、入力と出力の間に2つの中間層（または、隠れ層）があります。出力数（ユニット、ノード、またはニューロンと呼びます）は、レイヤが表現できる空間の次元です。言い換えると、内部表現を学習するときにネットワークが許容する自由度です。 \n",
-    "\n",
-    "モデルがより多くのノード（高次元の表現空間）やレイヤを持つと、ネットワークはより複雑な表現を学ぶことができます。しかし、同時にネットワークの計算コストが高くなり、不要なパターン（つまり学習データでの精度は向上するが、テストデータでの精度は向上しないパターン）の学習をしてしまうことがあります。これは*過学習*と呼ばれており、後で触れます。 \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "cGiwZcACxrPW"
-   },
-   "source": [
-    "\n",
-    "### 2. 損失関数とオプティマイザ\n",
-    "\n",
-    "モデルには、損失関数と学習用のオプティマイザが必要です。今回の課題は、二項分類問題です。モデルは確率（活性化関数としてのSigmoid関数を含む単一層）を出力するので、 `binary_crossentropy` という損失関数を使います。 \n",
-    "\n",
-    "損失関数は他にも選ぶことができます。例えば、 `mean_squared_error`が選べます。ただ一般に、 `binary_crossentropy`は、確率を扱うのに適しています。確率分布間、またはこの場合は正解データの分布と予測データの分布間の「距離」を測定します。 \n",
-    "\n",
-    "後に回帰問題をみてゆくとき（たとえば家の価格を予測するとき）、平均二乗誤差と呼ばれる別の損失関数を使います。\n",
-    "\n",
-    "次に、指定したオプティマイザと損失関数を使うよう、下の関数でモデルをコンパイルします。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Efbx8v3wxrPX"
-   },
-   "outputs": [],
-   "source": [
-    "model.compile(optimizer=tf.train.AdamOptimizer(),\n",
-    "              loss='binary_crossentropy',\n",
-    "              metrics=['accuracy'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## E. モデルを学習させる"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "12DJ2q7qxrPZ"
-   },
-   "source": [
-    "\n",
-    "### 1. 検証データセットを準備する\n",
-    "\n",
-    "学習中、モデルの精度を未知のデータで確認します（検証、Validation）。そのため、元の学習データから10,000個の例を分けて、*検証データセット*を準備します。\n",
-    "\n",
-    "なぜ今テストデータセットを使わないのでしょうか？なぜなら、学習データのみを使用してモデルを学習・調整し、その間に検証データセットを使います。そして、次にテストデータを1回だけ使用して精度を評価したいからです。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "Qy23KniexrPa"
-   },
-   "outputs": [],
-   "source": [
-    "x_val = train_data[:10000]\n",
-    "partial_x_train = train_data[10000:]\n",
-    "\n",
-    "y_val = train_labels[:10000]\n",
-    "partial_y_train = train_labels[10000:]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "4cwmnVW_xrPc"
-   },
-   "source": [
-    "\n",
-    "### 2. モデルを学習させる\n",
-    "\n",
-    " 512サンプルのミニバッチで40エポック、モデルを学習させます。これは、`x_train`と`y_train`テンソルの全サンプルを、40回繰り返し使って学習します。学習中に、検証セットからの1万サンプルでモデルの誤差(loss)と精度を監視します。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 1465
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 39038,
-     "status": "ok",
-     "timestamp": 1553304529889,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "YFQp5YG4xrPc",
-    "outputId": "8d878d2b-c757-4b1b-9189-a1fef6f36f56"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Train on 15000 samples, validate on 10000 samples\n",
-      "WARNING:tensorflow:From /usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "Use tf.cast instead.\n",
-      "Epoch 1/40\n",
-      "15000/15000 [==============================] - 2s 102us/sample - loss: 0.6912 - acc: 0.5622 - val_loss: 0.6885 - val_acc: 0.6330\n",
-      "Epoch 2/40\n",
-      "15000/15000 [==============================] - 1s 64us/sample - loss: 0.6834 - acc: 0.7144 - val_loss: 0.6782 - val_acc: 0.7389\n",
-      "Epoch 3/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.6676 - acc: 0.7596 - val_loss: 0.6589 - val_acc: 0.7664\n",
-      "Epoch 4/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.6412 - acc: 0.7755 - val_loss: 0.6293 - val_acc: 0.7717\n",
-      "Epoch 5/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.6035 - acc: 0.8057 - val_loss: 0.5907 - val_acc: 0.7964\n",
-      "Epoch 6/40\n",
-      "15000/15000 [==============================] - 1s 60us/sample - loss: 0.5574 - acc: 0.8243 - val_loss: 0.5472 - val_acc: 0.8109\n",
-      "Epoch 7/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.5075 - acc: 0.8373 - val_loss: 0.5013 - val_acc: 0.8285\n",
-      "Epoch 8/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.4590 - acc: 0.8557 - val_loss: 0.4603 - val_acc: 0.8395\n",
-      "Epoch 9/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.4153 - acc: 0.8696 - val_loss: 0.4247 - val_acc: 0.8489\n",
-      "Epoch 10/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.3776 - acc: 0.8797 - val_loss: 0.3960 - val_acc: 0.8544\n",
-      "Epoch 11/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.3461 - acc: 0.8871 - val_loss: 0.3727 - val_acc: 0.8623\n",
-      "Epoch 12/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.3198 - acc: 0.8944 - val_loss: 0.3549 - val_acc: 0.8665\n",
-      "Epoch 13/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.2983 - acc: 0.9009 - val_loss: 0.3395 - val_acc: 0.8717\n",
-      "Epoch 14/40\n",
-      "15000/15000 [==============================] - 1s 60us/sample - loss: 0.2789 - acc: 0.9055 - val_loss: 0.3282 - val_acc: 0.8753\n",
-      "Epoch 15/40\n",
-      "15000/15000 [==============================] - 1s 60us/sample - loss: 0.2627 - acc: 0.9097 - val_loss: 0.3191 - val_acc: 0.8762\n",
-      "Epoch 16/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.2481 - acc: 0.9157 - val_loss: 0.3114 - val_acc: 0.8764\n",
-      "Epoch 17/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.2345 - acc: 0.9203 - val_loss: 0.3051 - val_acc: 0.8791\n",
-      "Epoch 18/40\n",
-      "15000/15000 [==============================] - 1s 64us/sample - loss: 0.2225 - acc: 0.9239 - val_loss: 0.2998 - val_acc: 0.8816\n",
-      "Epoch 19/40\n",
-      "15000/15000 [==============================] - 1s 63us/sample - loss: 0.2116 - acc: 0.9264 - val_loss: 0.2954 - val_acc: 0.8823\n",
-      "Epoch 20/40\n",
-      "15000/15000 [==============================] - 1s 63us/sample - loss: 0.2018 - acc: 0.9307 - val_loss: 0.2924 - val_acc: 0.8833\n",
-      "Epoch 21/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1918 - acc: 0.9357 - val_loss: 0.2899 - val_acc: 0.8829\n",
-      "Epoch 22/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.1834 - acc: 0.9395 - val_loss: 0.2880 - val_acc: 0.8850\n",
-      "Epoch 23/40\n",
-      "15000/15000 [==============================] - 1s 63us/sample - loss: 0.1750 - acc: 0.9437 - val_loss: 0.2874 - val_acc: 0.8841\n",
-      "Epoch 24/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.1677 - acc: 0.9465 - val_loss: 0.2863 - val_acc: 0.8846\n",
-      "Epoch 25/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.1602 - acc: 0.9495 - val_loss: 0.2853 - val_acc: 0.8851\n",
-      "Epoch 26/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1536 - acc: 0.9524 - val_loss: 0.2864 - val_acc: 0.8836\n",
-      "Epoch 27/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.1473 - acc: 0.9554 - val_loss: 0.2863 - val_acc: 0.8847\n",
-      "Epoch 28/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1413 - acc: 0.9571 - val_loss: 0.2872 - val_acc: 0.8849\n",
-      "Epoch 29/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1359 - acc: 0.9598 - val_loss: 0.2892 - val_acc: 0.8839\n",
-      "Epoch 30/40\n",
-      "15000/15000 [==============================] - 1s 64us/sample - loss: 0.1304 - acc: 0.9615 - val_loss: 0.2891 - val_acc: 0.8851\n",
-      "Epoch 31/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1247 - acc: 0.9640 - val_loss: 0.2905 - val_acc: 0.8856\n",
-      "Epoch 32/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.1197 - acc: 0.9671 - val_loss: 0.2924 - val_acc: 0.8854\n",
-      "Epoch 33/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1148 - acc: 0.9681 - val_loss: 0.2950 - val_acc: 0.8845\n",
-      "Epoch 34/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1105 - acc: 0.9693 - val_loss: 0.2976 - val_acc: 0.8846\n",
-      "Epoch 35/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.1064 - acc: 0.9703 - val_loss: 0.3007 - val_acc: 0.8835\n",
-      "Epoch 36/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.1021 - acc: 0.9729 - val_loss: 0.3027 - val_acc: 0.8836\n",
-      "Epoch 37/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.0979 - acc: 0.9737 - val_loss: 0.3056 - val_acc: 0.8824\n",
-      "Epoch 38/40\n",
-      "15000/15000 [==============================] - 1s 61us/sample - loss: 0.0941 - acc: 0.9753 - val_loss: 0.3096 - val_acc: 0.8828\n",
-      "Epoch 39/40\n",
-      "15000/15000 [==============================] - 1s 62us/sample - loss: 0.0910 - acc: 0.9767 - val_loss: 0.3137 - val_acc: 0.8809\n",
-      "Epoch 40/40\n",
-      "15000/15000 [==============================] - 1s 63us/sample - loss: 0.0871 - acc: 0.9784 - val_loss: 0.3167 - val_acc: 0.8820\n"
-     ]
-    }
-   ],
-   "source": [
-    "history = model.fit(partial_x_train,\n",
-    "                    partial_y_train,\n",
-    "                    epochs=40,\n",
-    "                    batch_size=512,\n",
-    "                    validation_data=(x_val, y_val),\n",
-    "                    verbose=1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "KtrnLQqNxrPj"
-   },
-   "source": [
-    "\n",
-    "## F. 学習済みモデルを評価する\n",
-    "\n",
-    "学習したモデルの性能を見てみましょう。以下の2つの値が返されます。\n",
-    "\n",
-    "- 誤差（私たちのエラーを表す数値、低い値の方が優れています）\n",
-    "- 精度 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 51
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 1661,
-     "status": "ok",
-     "timestamp": 1553304550770,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "SvGYTAIuxrPj",
-    "outputId": "c1205dff-78ec-44b2-8dc1-6baa0c50c156"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "25000/25000 [==============================] - 1s 38us/sample - loss: 0.3388 - acc: 0.8698\n",
-      "[0.3387693747806549, 0.86984]\n"
-     ]
-    }
-   ],
-   "source": [
-    "results = model.evaluate(test_data, test_labels)\n",
-    "\n",
-    "print(results)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "GCI3laxDxrPl"
-   },
-   "source": [
-    "\n",
-    "このような、とても素朴なアプローチでも、約87％の精度を達成できました。より高度なアプローチでは、モデルは95％に近づくはずです。 \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "mdcPGcGYxrPm"
-   },
-   "source": [
-    "\n",
-    "### 1. 精度と誤差(loss)の時系列グラフを作成する\n",
-    "\n",
-    " `model.fit()`は、学習中に起こったことすべてを含む辞書を含む`History`オブジェクトを返します。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 719,
-     "status": "ok",
-     "timestamp": 1553304553418,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "JOkHmBPQxrPn",
-    "outputId": "168202f3-bfb0-4f6e-93ea-4839efee8992"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['acc', 'loss', 'val_acc', 'val_loss']"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "oKQ5YSCexrOj"
+      },
+      "source": [
+        "\n",
+        "このノートブックは、映画レビューの文章を、*ポジティブな評価*か*ネガティブな評価*かの二種類に分類します。これは、二項分類や二クラス分類と呼ばれ、重要かつ幅広く使える機械学習のタスクのひとつです。 \n",
+        "\n",
+        " [Internet Movie Database](https://www.imdb.com/)から5万の映画レビュー文章を集めたデータセットである、[IMDBデータセット](https://www.tensorflow.org/api_docs/python/tf/keras/datasets/imdb)を使います。これは学習用2万5千レビューとテスト用2万5千レビューに分けられます。学習セットとテストセットはポジティブ、ネガティブ同数のレビューが含まれます（balanced）。 \n",
+        "\n",
+        "このノートブックはTensorFlowでモデルを構築し学習するための高レベルAPI [tf.keras](https://www.tensorflow.org/guide/keras)を使います。 `tf.keras`を使用したより高度なテキスト分類チュートリアルは、 [MLCCテキスト分類ガイド](https://developers.google.com/machine-learning/guides/text-classification/)を参照してください。 \n"
       ]
-     },
-     "execution_count": 16,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "history_dict = history.history\n",
-    "history_dict.keys()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "g6OaI8IkxrPp"
-   },
-   "source": [
-    "\n",
-    "学習中の、以下4つの値の推移が保存されています。\n",
-    "\n",
-    "- acc 学習データセットに対する精度\n",
-    "- loss　学習データセットに対する誤差\n",
-    "- val_acc　検証データセットに対する精度\n",
-    "- val_loss　検証データセットに対する誤差\n",
-    "\n",
-    "学習および検証中に監視される各メトリックに1つです。これらを使って、比較のために学習・検証データセットの誤差、精度（正解率）をプロットできます。 \n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 376
     },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 1281,
-     "status": "ok",
-     "timestamp": 1553304557228,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "luU9i7G9xrPp",
-    "outputId": "0e023cb5-395c-41c7-99db-72cc6296c166"
-   },
-   "outputs": [
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAe8AAAFnCAYAAACPasF4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzs3XlcVPX+x/HXmRlAETQXMDUtw1DB\nzGvl1dRwwUSt26VFuZW2WFrmVUsrI40WNS0ttbpFi93SStLA7FdqWXHrlmlliwtm2s3dBBeU3Vl+\nf0yMEoMOyMDM8H4+HvMYzplzzny/HJjPfHfD4XA4EBEREb9hqu0EiIiISOUoeIuIiPgZBW8RERE/\no+AtIiLiZxS8RURE/IyCt4iIiJ9R8JY6LSUlhYSEBBISEoiNjaVv376u7by8vEpdKyEhgZycnFMe\nM2fOHN5+++0zSXK1u+WWW0hPT6+Wa7Vv3579+/fz8ccf8+CDD57R+73zzjuunz353Xpq8uTJ/Otf\n/6qWa4nUFkttJ0CkNj366KOun/v168eTTz7JJZdcUqVrrVy58rTHTJw4sUrX9jcDBgxgwIABVT4/\nOzubV155haFDhwKe/W5F6hKVvEVOYfjw4TzzzDMMGjSI9evXk5OTw8iRI0lISKBfv3689tprrmNL\nS51r165l2LBhzJkzh0GDBtGvXz/WrVsHlC319evXj8WLF3PdddfRq1cvZs6c6brWiy++SI8ePbj2\n2mt588036devn9v0LVmyhEGDBnHFFVdw4403smfPHgDS09MZN24cycnJDBw4kMGDB/PLL78AsGvX\nLq6//nri4+OZOHEiNput3HX/85//cNVVV5XZd/XVV/P555+f8ndQKj09nVtuueW07/fJJ59w1VVX\nMXDgQK655hqysrIASEpKYu/evSQkJFBSUuL63QK88cYbDB48mISEBO666y4OHTrk+t3Onz+fW2+9\nlb59+3LrrbdSWFhY0a0FYMuWLSQlJZGQkMDVV1/NF198AUB+fj533303gwYNon///kyZMoXjx49X\nuF+kpil4i5zGxo0b+eCDD+jatSsvvPAC55xzDitXruT1119nzpw57Nu3r9w5mzdv5qKLLmLFihXc\ncMMNvPDCC26v/c0335CWlsa7777LokWL2L9/P7/88guvvPIK7733Hm+99VaFpc6DBw/y2GOP8dpr\nr/HRRx/Rpk2bMtXBn3/+OTfccAOrVq3ir3/9K6+//joAs2fPpkePHqxevZqbb76Z9evXl7t2jx49\n2L9/P7t27QKcAXj//v1cdtllHv8OSlX0flarlcmTJ/P444+zatUq+vXrx6xZswCYMWMGLVq0YOXK\nlQQHB7uu9cMPP/Dqq6+ycOFCVq5cScuWLZkzZ47r9ZUrV/LMM8/w8ccfc+jQIT7++OMK02W327n3\n3nu56aabWLlyJdOmTWPixInk5eWxbNkyGjZsyIoVK1i1ahVms5lt27ZVuF+kpil4i5xGXFwcJpPz\nX2XKlClMnToVgNatWxMREcHu3bvLndOgQQPi4+MBiI2NZe/evW6vfdVVV2E2m2nevDlNmzZl3759\nfPPNN3Tr1o3IyEhCQkK49tpr3Z7btGlTvvvuO84++2wALrnkElewBYiKiqJTp04AxMTEuALst99+\ny+DBgwHo3Lkz559/frlrBwcH07dvXz799FMAVq9eTXx8PBaLxePfQamK3s9isfDVV1/RpUsXt+l3\nJzMzk4EDB9K0aVMArr/+er788kvX63FxcZx11llYLBaio6NP+aVi9+7d5OTkMGTIEAAuvPBCWrZs\nyYYNG2jSpAnff/89//3vf7Hb7Tz66KN07Nixwv0iNU1t3iKn0ahRI9fPGzZscJU0TSYT2dnZ2O32\ncueEh4e7fjaZTG6PAQgLC3P9bDabsdlsHD16tMx7Nm/e3O25NpuN+fPn8+mnn2Kz2cjPz6dt27Zu\n01B6bYDc3Nwy79uwYUO31x84cCBvvPEGN998M6tXr2bMmDGV+h2UOtX7LVy4kIyMDEpKSigpKcEw\njAqvA3Do0CEiIyPLXOvgwYOnzXNF1woPDy/zng0bNuTQoUMMGTKE3Nxc5s2bx6+//srf/vY3Hnzw\nQQYNGuR2/8m1AyI1QSVvkUq47777GDhwIKtWrWLlypU0bty42t8jLCyMgoIC1/aBAwfcHvfhhx/y\n6aefsmjRIlatWsW4ceM8un7Dhg3L9KQvbTP+s969e7NlyxZ+++03fvvtN7p37w5U/ndQ0futX7+e\nl19+mRdeeIFVq1Yxbdq006a9WbNmHDlyxLV95MgRmjVrdtrz3GnatCm5ubmcvDbTkSNHXKX6pKQk\nlixZwocffsimTZtYtmzZKfeL1CQFb5FKOHjwIJ06dcIwDDIyMigsLCwTaKtD586dWbt2LYcOHaKk\npKTC4HDw4EFatWpFkyZNOHz4MCtWrCA/P/+01+/SpYurLXj9+vXs3LnT7XHBwcH06tWLp556iv79\n+2M2m13vW5nfQUXvd+jQIZo2bUrLli0pLCwkIyODgoICHA4HFouFgoICrFZrmWv16dOHjz/+mMOH\nDwOwePFi4uLiTptnd8455xzOPvtsPvzwQ1facnJy6Ny5M88//zxLly4FnDUf55xzDoZhVLhfpKYp\neItUwvjx47n77ru56qqrKCgoYNiwYUydOrXCAFgVnTt3JjExkcTEREaMGEHfvn3dHnfllVdy5MgR\nBgwYwMSJE5kwYQL79+8v02vdnfvuu4/PPvuM+Ph43nzzTS677LIKjx04cCCrV69m0KBBrn2V/R1U\n9H69e/cmMjKS+Ph4brvtNm6++WbCw8MZN24c7du3p1GjRvTs2bNMf4HOnTszatQobrzxRhISEjh2\n7Bj33HPPKfNbEcMwePrpp1m0aBGDBg1i2rRpzJs3j9DQUK6++mree+89Bg4cSEJCAkFBQVx99dUV\n7hepaYbW8xbxPQ6Hw1Wiy8zMZO7cuaqeFREXlbxFfMyhQ4fo3r07e/bsweFwsGLFClePbBERUMlb\nxCe9/fbbLFiwAMMwOP/885k+fbqrI5WIiIK3iIiIn1G1uYiIiJ9R8BYREfEzfjPDWnb2MY+Oa9w4\nlMOHq3fcbW1Sfnyb8uPblB/fpvycXkREuNv9AVfytljMtZ2EaqX8+Dblx7cpP75N+am6gAveIiIi\ngU7BW0RExM8oeIuIiPgZBW8RERE/49Xe5jNmzODHH3/EMAySk5Pp3LkzAL///juTJk1yHbdr1y4m\nTpzIVVdd5c3kiIiIBASvBe9169axY8cO0tLS2L59O8nJyaSlpQHOpfQWLlwIgNVqZfjw4fTr189b\nSREREQkoXqs2X7NmDfHx8QBERUWRm5tLXl5eueMyMjIYOHAgDRo08FZSREREAorXSt45OTnExsa6\ntps0aUJ2djZhYWFljluyZAkLFiw47fUaNw71eAxdRYPa/ZXy49uUH9+m/PimmTNnsmnTJrKzsyks\nLKRNmzY0atSI55577rTnpqenEx4ezoABA9y+Pn36dEaMGEHr1q2rlLbhw4czdepUoqOjK31uTd2f\nGpthzd36J99//z3nn39+uYDujqez1kREhJ9yNraMDAtz5wazdauJ6Gg7EyaUkJho9ejateF0+fE3\nyo9vU358W23mp7o/O0eOvJuIiHBef/0tfv11O2PHTgA8m02zd+8Bpzx21KhxHl/LnZISK4cP51f6\nfG/cn4q+DHgteEdGRpKTk+PaPnDgABEREWWOyczMpEePHt5KQjkZGRZGj67v2s7KMv+xXejTAVxE\npDbV5Gfn+vXfsnjxIgoKChg79h6+//47MjM/wW6306NHT267bRSvvprKWWedRdu2UaSnv4NhmNix\n43/06dOf224bxdixo7j33vv57LNPyM/PY+fOHezZs5tx4ybSo0dPFi36N6tXf0TLlq2wWq0kJd1I\n166XlEtLXl4e06c/Ql7eMaxWKxMm3Ef79h2YO/cptmzJwmazkZh4HYMHX8XcuU+xfftWiopKXPu8\nyWtt3j179mTVqlUAbNq0icjIyHIl7A0bNtChQwdvJaGcuXOD3e6fN8/9fhERqfnPzu3bt/H008/R\noUNHAP71r1d46aV/s2LF/5GfX7bv1ObNm3jooUd48cXXePfdtHLXOnDgd2bPns/48ZNYvjydo0dz\nSU9fQmrqAiZNmswPP6yvMB1LlrxNbGwnnn02lfHjJ/Lss09z9GguX331X158cQEvvPAqVqvVtW/x\n4sWufd7mtZJ3165diY2NJSkpCcMwSElJKddOkZ2dTdOmTb2VhHK2bnX/XaWi/SIiUvOfne3aXUBw\nsPOLQb169Rg7dhRms5kjR45w9OjRMse2b9+BevXqVXitzp27AM7a4Ly8PHbv3sX550cRElKPkJB6\ndOwYW+G5W7ZsZsSIkQB06BDD7t27aNiwEa1bn8vkyffSt288CQlDCA4OpnXrc7nrrrvo2bMPCQlD\nzvRXcFpebfM+eSw3UK6U/f7773vz7cuJjraTlVW+01tUlN3t8f7WPi4i4g0VfXZGR7v/7DxTQUFB\nAOzfv4+0tDdZsOBNQkNDGT58aLljzeZTd2Q++XWHw4HDASbTiS8dhlHxuYZhlOmvZbc78ztnznx+\n/nkLH3+8kpUrP+CZZ55nzpz5HDiwk3feSXft86Y6VeScMKHE7f7//c/E5Mkh/PrribtY2saTlWXG\nZjNcbTwZGX6ziqqISLWo6LNz/Hj3+6vLkSNHaNy4MaGhofz88xb279/P8ePHz+iaLVq04Ndft2O1\nWjl8+DBbtmRVeGyHDjF8//23AGzcuIG2baPYt28vS5Yspn37DowdO4Hc3FzXvtjYWNc+b6tTkchZ\nai5k3jxnaToqys6FF9pZs8bMggXBvPZaEIMGWbnzzuM880zFbTwqfYtIXfLnz87oaDvjx3u/JvKC\nC6KpXz+Uu+66jQsv7MLVV1/DnDmz6Nz5oipfs0mTpgwYkMAdd4zg3HPbEhMTW2HpfejQfzBjxqOM\nG3cndrude+99gGbNIti48Uc++eQjgoKCGDLkb659SUlJgIkhQ/5W5fR5ynC4G8Plgzztfl+VrvrH\nj8P//Z+FF14I5ocfSm+iAyhfn2KxONi7t/xkM96ioS6+TfnxbcqPb6ut/Hz44fsMGJCA2WxmxIgk\nnn76WSIjm5/xdQNiqJg/CQpyfrP8+9+trF1r5oUXglixwv2vxlttPCIiUjMOHjzIqFE3ExQUzBVX\nJFRL4K5pCt4nMQzo3t1G9+42UlODmDq1fA9Gb7fxiIiIdw0ffgvDh99S28k4I3Wqw1pljB59nNTU\nQtq1s+GsQodOnWzEx6u9W0REapeC9ykkJlr56qsCtm3Lo39/Kxs3mhk8OJTffivbFp6RYSEuLpQW\nLcKIiwtVj3QREfEqBW8PNGwIixYVMnp0CT//bCYhIZQ1a5wd2zSkTEREapqCt4fMZnj88WJmzy7i\n6FGD666rz1tvWTTlqoiI1DgF70oaMeI477xTSFgYTJhQny1bNOWqiEhljR59Kxs3biyz78UXn+Pt\ntxe5PX79+m+ZMuV+ACZPvrfc6+++m8arr6ZW+H7btv3Czp07AEhJeZDi4qKqJp3rrruKggLPVrr0\nFkWYKujVy8aKFflccIENh8P93HoaUiYiUrEBAwayYsWKMvsyMz8lPv6K0547c+bTlX6///znU3bt\n2gnAo48+QUhIxfOh+wM1zFbR+ec7+PDDAq6+OpTNm8vPzqMhZSIiFevf/wrGjr2DW265E4AtW7KI\niIggIiKSb75ZyyuvvEhQUBDh4eE89tjMMucOGdKfDz74hG+/Xcf8+XNo0qQpTZs2cy3xOX36I2Rn\nH6CwsJDbbhvF2We34L330vnPfz6lcePGPPzwg7zxRhp5ecd44onHOH78OCaTicmTp2IYBtOnP0LL\nlq3Ytu0XoqPbM3nyVLd5OHDg9zLnP/nkTCyWMB57bCoHD+ZQUlLCyJGjueSSbuX2de9+2Rn9/hS8\nz0CjRrB6dQE33lifzz6zAA7atbNz331awERE/Mcjj4Tw/vvVGw6uusrKI48UV/h648ZNaN26NZs3\nbyQmphOffvoxAwYkAHDs2DFSUqbRsmUrHn/8YdauXUNoaGi5a6SmPsfUqY9zwQXRTJo0jpYtW3Hs\n2FG6devOoEFXsmfPbqZOncyCBYv461970KdPf2JiOrnOf+WVF7nyyqvp3/8KPvtsNQsWvMTIkaP5\n+ecsHn10Bo0bNyExcTDHjh0jPLz8TGd/Pv+5557jqquuIzf3CM8//zLHjh1jzZov2b59W7l9Z0rV\n5mfIYoG0tEKmTSsCDIKDYeBABW4RkdO58sor+eSTjwH48svP6dOnPwBnnXUWs2ZNY+zYUXz//Xcc\nPep+oY99+/ZxwQXRAHTp0hWA8PCGZGVt4q67bmP69EcqPBfg55+z+MtfLgaga9dL+OWXnwFo1ao1\nTZs2w2Qy0axZRLk1xCs6f/PmzZx77nkUFOTz+ONTWb/+G+Ljr3C770yp5F1NRo06zi+/mHj99WAm\nTarH888XnXKpORERX/HII8WnLCV7y4ABA3j++X8xYMBAWrduQ8OGDQF44onHeeqpuZx3XluefnpW\nheefvLRn6TIdH3+8kqNHj/L8869w9OhRbr99+ClScGLJz+PHrRiG83p/Xqik4iVAyp5vMpmoV68e\nqan/ZsOGn1ix4n2+/PILkpNT3O47Eyp5V6Np04rp2tXG0qVBvPZaUG0nR0TEp4WFhREVdQFvvPGa\nq8ocID8/j+bNz+bYsWOsX/9dhcuANmsWwc6dv+FwOPj+++8A5zKiLVq0xGQy8Z//fOo61zAMbDZb\nmfM7doxh/Xrnkp8//PAdHTp0rFT6/3x+p06dXOt8X3RRFyZNepDffvuf231nSiXvahQSAq++Wkh8\nfChTp4Zw4YU2Lr1Uvc5FRCoyYEAC06alkJLyuGvfNddcz113jaR16zbceOMIFix4iVGjxpQ7d9So\nMUyZ8gBnn93CtbhInz79mDz5XjZv3siQIX8jMjKS1157mYsu+gtz5z5Vpu389tvv5IknHuf995dh\nsQTx4INTsVo9b/b88/mzZ88iL89KaurzvPdeOiaTiRtuGE6LFi3L7TtTWhLUCz7/3MzQofWJjHSw\nenUBkZFV/xX7Qn6qk/Lj25Qf36b8+LaaXBJU1eZecPnlNpKTS9i/38To0fU4+Yuc5kEXEZEzpeDt\nJf/8ZwmDBx/nyy8tTJ8eAmgedBERqR4K3l5iGDB/fhFRUXaefz6Y99/XPOgiIlI9FLy9qGFDeO21\nQkJDHYwbV4+ff9Y86CIicuYUNbysQwc7zzxTRH6+gaWC2nHNgy4iIpWh4F0DEhOtjB5dQkmJ+1lb\nNA+6iIhUhoJ3DXn44WL++ldnt/Pmze1YLA5iYmykphZqHnQREakUdXOuIUFB8MorRfTvH0pOjkF6\neiE9ethOf6KIiMifqORdg5o3d/DKK0U4HHDvvfUorvmphEVEJAAoeNew7t1t3HbbcbZvN5GaqiFi\nIiJSeQreteCBB4pp1szO008Hs3u3lh4TEZHKUfCuBY0aOTuwFRQYpKSE1HZyRETEzyh415KhQ61c\neqmN998PIjPTfPoTRERE/qDgXUtMJpg5swiTyUFycgglGuotIiIeUvCuRRdeaOfWW4+zbZuZF19U\n5zUREfGMgnctmzz5ROe1PXvUeU1ERE5PwbuWqfOaiIhUloK3Dxg61Moll9hYvjyI//zH2XktI8NC\nXFwoFgvExYVqzW8REXHxavCeMWMGw4YNIykpiZ9++qnMa/v27eMf//gH1113HQ8//LA3k+HzTCaY\nNcvZee3BB0NYssTC6NH1ycoyY7NBVpaZ0aPrK4CLiAjgxeC9bt06duzYQVpaGtOnT2f69OllXp85\ncya33XYbS5cuxWw2s3fvXm8lxS9ceKGdW25xdl575BH31efz5qlTm4iIeDF4r1mzhvj4eACioqLI\nzc0lLy8PALvdznfffUe/fv0ASElJoWXLlt5Kit8o7byWne2+49rWrWrlEBERL64qlpOTQ2xsrGu7\nSZMmZGdnExYWxqFDh2jQoAFPPPEEmzZt4pJLLmHixImnvF7jxqFYLJ5NZhIREX5Gaa8tERHw5JNw\n223uX4+JMfw2bycLhDycTPnxbcqPb1N+qqbGGlEdDkeZn3///XdGjBhBq1atGDVqFJmZmfTp06fC\n8w8fLvDofSIiwsnOPnamya01gwdD27YN+N//ypey7767kOxs/17729/vz58pP75N+fFtyo9n13TH\na/WwkZGR5OTkuLYPHDhAREQEAI0bN6Zly5a0adMGs9lMjx49+OWXX7yVFL9iMsHLLxdiGA6Cgx2Y\nzRATYyM1tZDERP8O3CIiUj28Frx79uzJqlWrANi0aRORkZGEhYUBYLFYaN26Nb/99pvr9bZt23or\nKX6nc2dn57WSEoMZMyAzs0CBW0REXLxWbd61a1diY2NJSkrCMAxSUlJIT08nPDycAQMGkJyczOTJ\nk3E4HERHR7s6r4nTgw8Ws3y5hcceMzFkiEFkpOP0J4mISJ3g1TbvSZMmldnu0KGD6+dzzz2Xt99+\n25tv79fOOgvuv7+EBx6ox9y5wcyYUVzbSRIRER+hsUc+7KabjhMVBa+/HsSOHZr3XEREnBS8fVhQ\nEDz+OBw/bjBrluY9FxERJwVvHzdsGHTqZOPddy1s2qTbJSIiCt4+z2SCKVOKcTgMnnhCpW8REVHw\n9gt9+9q47DIrH31k4euvPZtlTkREApeCtx8wDHjoIWdv82nTgnFo1JiISJ2m4O0nLr3UTkLCcdat\ns/Dxxyp9i4jUZQrefiQ5uQSTycH06SHYbLWdGhERqS0K3n6kQwc7Q4daycoyk55eY2vKiIiIj1Hw\n9jP33VdMcLCDWbNCKNakayIidZKCt59p3drBrbceZ+dOEwsXBtV2ckREpBYoePuh8eNLCAtz8PTT\nweTlQUaGhbi4UFq0CCMuLpSMDFWpi4gEMgVvP9SsmYMxY0rIyTExfnw9Ro+uT1aWGZvNICvLzOjR\n9RXARUQCmIK3n7rzzhKaNbPzwQfug/S8ecE1nCIREakpCt5+KiwM7rmnBLvd/WpjW7fq1oqIBCp9\nwvuxESOOExTkfrq16Gh7DadGRERqioK3HwsJca757c748SU1nBoREakpCt5+bsaMYlq2tAMOzGYH\nMTE2UlMLSUy01nbSRETESxS8/ZzZDDNnFgEGQ4ZYycwsUOAWEQlwCt4BYOBAG1262Fi+PIjNm3VL\nRUQCnT7pA4BhOKdNBZg9W0PEREQCnYJ3gIiPt9G1q43/+78gNm7UbRURCWT6lA8QKn2LiNQdCt4B\npF8/GxdfbOPDD4PYsEG3VkQkUOkTPoCcXPp+6imVvkVEApWCd4Dp29fGJZfYWLkyiJ9+0u0VEQlE\n+nQPMIYB99+vtm8RkUCm4B2A4uJsdOtmZeXKIH78UbdYRCTQ6JM9ADlL3865zZ96KqSWUyMiItVN\nwTtA9e5to3t3Kx99ZOH773WbRUQCiT7VA5RK3yIigUvBO4D16mXjssusrF5t4bvvdKtFRAKFPtED\nnErfIiKBR8E7wF12mY1evax8+qmF2bODiYsLpUWLMOLiQsnIsNR28kREpAoUvOuA++5zlr6ffDKE\nrCwzNptBVpaZ0aPrK4CLiPghBe86oEcPG6GhDrevzZuniVxERPyNV4tdM2bM4Mcff8QwDJKTk+nc\nubPrtX79+nH22WdjNpsBmD17Ns2bN/dmcuq0oiL3+7du1fc3ERF/47XgvW7dOnbs2EFaWhrbt28n\nOTmZtLS0Mse8/PLLNGjQwFtJkJO0b28nK8tcbn90tL0WUiMiImfCa8WuNWvWEB8fD0BUVBS5ubnk\n5eV56+3kNCZMKHG7f/x49/tFRMR3ea3knZOTQ2xsrGu7SZMmZGdnExYW5tqXkpLCnj17uPjii5k4\ncSKGYVR4vcaNQ7FYypcc3YmICK96wn1QdeRn1Cho2ND5fOwYnHsuzJwJSUn1qyGFlaP749uUH9+m\n/Pi2mspPjXU1djjKdpgaN24cvXv3plGjRtx9992sWrWKhISECs8/fLjAo/eJiAgnO/vYGaXVl1Rn\nfvr3hxUrTMTFhWI2O+jdO5/s7Gq5tMd0f3yb8uPblB/f5o38VPRlwGvV5pGRkeTk5Li2Dxw4QERE\nhGv773//O02bNsVisXD55ZezdetWbyVFThIdbeeWW47z668m/v3voNpOjoiIVIHXgnfPnj1ZtWoV\nAJs2bSIyMtJVZX7s2DFGjhxJSYmzvfWbb77hggsu8FZS5E8mTSqhYUMHs2eHcPhwbadGREQqy2vV\n5l27diU2NpakpCQMwyAlJYX09HTCw8MZMGAAl19+OcOGDSMkJISYmJhTVplL9Wra1MHEicWkpNRj\nzpwQpk0rru0kiYhIJRiOPzdG+yhP2xHUhuKZ4mLo3bsBu3cbfP55Pu3a1cyfge6Pb1N+fJvy49sC\nos1bfFtICKSkFGO1Gjz2mBYtERHxJwreddjgwVYuu8zKypVBfPGFZ8PwRESk9il412GGAY89Voxh\nOHj44RBsttpOkYiIeELBu47r3NnO0KFWNm0ys3ixho6JiPgDBW8hObmY0FAHTzwRjGawFRHxfQre\nQosWDu6+u4QDB0w8+6yWCBUR8XUK3gLAmDEltGhh54UXgtm9u+I55kVEpPYpeAsADRo4q8+Ligym\nTdPQMRERX6bgLS7XX2+lSxcb6elBfPed/jRERHyVPqHFxWRyDh0DmDq1Hv4x956ISN2j4C1ldO9u\no2tXG99+a+bss8OIiwslI6PGVo4VEREPKHhLGRkZFtavd8625nAYZGWZGT26vgK4iIgPUfCWMubO\ndT9UbN48DSETEfEVCt5Sxtat7v8kKtovIiI1T5/IUkZ0tN3t/gsucL9fRERqnoK3lDFhQonb/R06\nKHiLiPgKBW8pIzHRSmpqITExNiwWB+3b22jY0MGHH1rYtk0zr4mI+AIFbyknMdFKZmYBe/fm8cUX\nBcydW0RxscE999TDrgK4iEitU/CW07rySitXXnmctWst/PvfWjZURKS2KXiLR554ophGjRw8/niI\nFi4REallCt7ikebNHTz+eBFhRLqNAAAgAElEQVT5+Qb33aepU0VEapOCt3hs2DArcXFWPvnEwtKl\nmnFNRKS2KHiLxwwD5swpIjTUwZQp9cjOVvW5iEhtUPCWSmnTxsFDDxVz+LDBQw9p3W8Rkdqg4C2V\ndtttx7nkEhvLlgWxYoWqz0VEapqCt1Sa2QzPPFNEcLCDBx4IITe3tlMkIlK3KHhLlbRvb+fee0vY\nv9/EY4+p+lxEpCYpeEuVjR1bQkyMjYULg/n8c3NtJ0dEpM5Q8JYqCw6GuXOLMJsd3HVXPfbuVe9z\nEZGaoOAtZ6RLFzuPPlpMdraJW2+tT1FRbadIRCTwKXjLGcnIsLBoURCG4eD7780MG1Zfs6+JiHiZ\ngrdUWUaGhdGj67NlixmHw1llvmaNhXHj1IFNRMSbFLylyubODXa7Py0tiC++UAc2ERFvUfCWKtu6\nteI/nzvuqMfOnerAJiLiDQreUmXR0Xa3+1u0cHDokImbb65Pfn4NJ0pEpA7wKHhv3LiRzz77DIBn\nnnmGm2++mW+//darCRPfN2FCidv9jzxSzIgRJWzaZOaee7R8qIhIdfMoeE+bNo22bdvy7bffsmHD\nBqZOncr8+fNPe96MGTMYNmwYSUlJ/PTTT26PmTNnDsOHD69cqsUnJCZaSU0tJCbGhsXiICbGRmpq\nIYmJVmbMKOavf7WybFkQzz7rvm1cRESqxqNVJUJCQjjvvPNIS0tj6NChtGvXDpPp1HF/3bp17Nix\ng7S0NLZv305ycjJpaWlljtm2bRvffPMNQUFBVc+B1KrERCuJidZy+4OD4dVXixgwIJTp04Pp1MlG\nv362WkihiEjg8ajkXVhYyIoVK1i9ejW9evXiyJEjHD169JTnrFmzhvj4eACioqLIzc0lLy+vzDEz\nZ87knnvuqWLSxddFRjp4/fVCgoNh1Kj6/PqrOrCJiFQHj0re9957L2+88Qb33HMPYWFhPPvss9xy\nyy2nPCcnJ4fY2FjXdpMmTcjOziYsLAyA9PR0unXrRqtWrTxKaOPGoVgsng0/iogI9+g4f+HP+Rkw\nAF56CW6+GW69NYy1a/07P+4oP75N+fFtyk/VeBS8u3fvTqdOnQgLCyMnJ4cePXrQtWvXSr2R46Re\nS0eOHCE9PZ3XXnuN33//3aPzDx8u8Oi4iIhwsrOPVSptviwQ8jNoEIweHUJqajA33QQvvngMS4As\nAx4I9+dkyo9vU358mzfyU9GXAY+qzR9//HFWrFjBkSNHSEpKYtGiRTzyyCOnPCcyMpKcnBzX9oED\nB4iIiADg66+/5tChQ9x4442MHTuWTZs2MWPGDA+zIv4oJaWYyy+3snw53H13Pazlm8lFRMRDHgXv\nzZs3c/3117NixQoSExOZO3cuO3bsOOU5PXv2ZNWqVQBs2rSJyMhIV5V5QkICH374Ie+88w7PPfcc\nsbGxJCcnn2FWxJdZLPDvfxdy2WWQkRHE2LH1sKn/mohIlXhUeVla5Z2ZmcmECRMAKClxP8a3VNeu\nXYmNjSUpKQnDMEhJSSE9PZ3w8HAGDBhwhskWfxQWBitWQP/+NtLTgzCZ4NlnizBrJlURkUrxKHi3\nbduWwYMH06RJEzp27MiyZcto1KjRac+bNGlSme0OHTqUO+acc85h4cKFHiZX/F3DhpCWVsDQoaEs\nXRqEYcD8+QrgIiKV4VHwnjZtGlu3biUqKgqAdu3a8eSTT3o1YRK4wsOdAXzYsFCWLHGWwOfOVQAX\nEfGUR8G7qKiITz/9lHnz5mEYBl26dKFdu3beTpsEsJNL4GlpzgD+zDNFnGbuHxERwcMOa1OnTiUv\nL4+kpCSGDh1KTk4OU6ZM8XbaJIBkZFiIiwvFYoG4uFAyMiyuAN6li4233w5i4sQQ7O7XOhERkZN4\nVPLOycnh6aefdm337dtX85GLxzIyLIweXd+1nZVl/mPbOQ/6O+8UcP31obz5ZjCGAbNnF6sELiJy\nCh5Pj1pYWOjaLigooLi42GuJksAyd677hUnmzXPuP+ssWLKkgM6dbSxaFMx996kELiJyKh6VvIcN\nG8agQYPo1KkT4By3PX78eK8mTALH1q3uvyOevL80gF97bSgLFwZjMsGsWSqBi4i449FH43XXXcfb\nb7/N3//+dxITE1m8eDHbtm3zdtokQERHuy9G/3l/48awdGkBsbE2Xn89mJEj63Ga9W9EROokj8s1\nLVq0ID4+nv79+9O8efMK1+cW+bMJE9xP6DN+fPn9TZrAu+8W0LOnlQ8+CGLAgAZs2qTit4jIyar8\nqXjyQiMip5KYaCU1tZCYGBsWC8TE2EhNLXS7Djg4A/iSJYWMG1fM//5nYvDgUBYvDpCVTEREqkGV\ng7dhaG1m8VxiopXMzAKOH4fMzIIKA3cpiwWmTCnhjTcKCAqCcePqc++9IRQV1VCCRUR82CmLM3Fx\ncW6DtMPh4PDhw15LlEiphAQbq1fnM3JkfRYtCubHH828+moh552nmh8RqbtOGbzfeuutmkqHSIXO\nO8/BBx8U8NBDISxcGEx8fAOee66QhAQtSyYiddMpg3erVq1qKh0ip1SvHsyZU8yll9q4//56jBgR\nyj//WcyDD5ZgUXO4iNQx6sYrfiUpycqKFQW0bWvn2WdDuO66+vz+u/pfiEjdouAtfic21s7HH+cz\nZMhxvvrKQp8+oSxfruK3iNQdCt7ilxo2hAULipg+vYiCAoPbb6/P7bfXIydHpXARCXwK3uJzSlcg\na9EizLUCmTuGAXfccZzPPsunWzcry5cH0bu3SuEiEvgUvMWnlK5AlpVlxmYzXCuQVRTAAc4/38F7\n7xXy2GNF5Oc7S+F33KFSuIgELgVv8SmnW4GsImYz3HmnsxR+6aU23nsviMsvD+X991UKF5HAo+At\nPsWTFchOJSrKwfLlBTz2WBF5eQYjR6oULiKBR8FbfIqnK5CdSkWl8OXLLWhKfhEJBAre4lMqswLZ\n6ZSWwh991FkKv/32+gwaFMpHH5kVxEXEryl4i08puwKZ47QrkJ2O2Qx33eUshQ8Zcpz1683cdFMo\n/fs728PtnhfoRUR8hnrziM9JTLRWOVhXJCrKwWuvFZGVVcLcucEsW2Zh5Mj6dOhgY8KEEq6+2orZ\nXK1vKSLiNSp5S53SsaOd1NQivvwyn6FDj/PLLybuvLM+vXo1YPFiC9bq/c4gIuIVCt5SJ7Vr5+C5\n54pYsyaf4cNL2LnTYNy4+nTv3oCFC4MoLq7tFIqIVEzBW+q0885zMGdOMWvX5nPbbSX8/rvBxIn1\n6NKlASkpIWzbpiFmIuJ7FLzFb3k6jaonzjnHwcyZxXzzTT533+3s2f7CC8FcdlkYV19dnyVLLBQW\nVlfKRUTOjIK3+KWqTKPqibPPdpCSUswPP+Tz0kuF9O5tZc0aC3ffXZ+LLgojOTmEzZv1byMitUuf\nQuKXqjqNqqdCQuDvf7fy7ruFrF2bx7hxxQQFOXjllWD69GnAoEGhvPWWhfz8ank7EZFKUfAWv3Sm\n06hWRtu2DqZMKeGHH/J57bVC+vWzsn69iQkT6tO8OYwaVY/337dQUFDtby0i4pbGeYtfio62k5VV\nfmB2ZaZRraygIBgyxMqQIVZ27TJ4660gli0LYdmyIJYtCyI01EF8vJW//c1K//5WGjTwWlJEpBbY\n7XDggMGOHSZ27TLYudPEzp2lzyZCQmDFCmjY0PtpUfAWvzRhQgmjR9cvt78q06hWRevWDh54oISn\nngrhs8/yWb7cwvLlQa5HaKiD/v1PBPKwsBpJlohUg7w8yMoykZVlZssWE7/+6gzSu3ebKCpyPwLl\n7LPtXHSRs8mtJih4i19yzsBWyLx5wWzdaiI62s748SXVPjPb6RgGXHihnQsvLCE5uYSNG0383/85\nA/n77zsf9es76NfPyhVXWImLs9GypSZWF/EFJSWwfbvpj0DtDNZZWSZ27Srf/HbWWQ6io+20aWOn\nTRsH555r59xzndvnnOOgXj2IiAgnO7tm0q7gLX7LG9OonomTA/nkySVs3mzi/fctLF9u4YMPgvjg\ngyAA2re30aePjT59rHTvblP1uoiX2e2wc6fBli0mtmxxlqazskxs22bi+PGyJelmzez07m0lJsZO\nhw52Ona00a6dvUaqwitDwVvECwwDYmPtxMaW8MADJfzyi4nMTDOZmRa++spMaqqZ1NRggoMddOt2\nIph36mTHpG6kIlXicDjbpEtL0qWB+uefTRQUlA3SoaEOLrzQGZw7drTTsaMzWEdE+EfNmFeD94wZ\nM/jxxx8xDIPk5GQ6d+7seu2dd95h6dKlmEwmOnToQEpKCoah2awk8BiGsyNddLSdUaOOU1wM33xj\ndgXz//7X+Zg2LYSmTe307GmjWzcbl15qo1MnO0FBtZ0DEd+Rn0+5jmI7dhh/PJvIzy8bR4KCHFxw\nQWkp2k6HDjY6dLDTurXDr78oey14r1u3jh07dpCWlsb27dtJTk4mLS0NgMLCQj744APefPNNgoKC\nGDFiBN9//z1du3b1VnKkDsvIsDB37om28QkTar5t/GQhIdCrl41evWxMmVJCTo7B5587A3lmptnV\n6Q2gfn0HXbo4A/mll9q45BI7TZv6R8lAxFMOhzMoZ2cb5OQY5OSY/nh2PrKzDXbtcgbpnBz3EbdB\nAwdt2thp29ZepiTdtm1gfgH2WvBes2YN8fHxAERFRZGbm0teXh5hYWHUr1+f119/HXAG8ry8PCIi\nIryVFKnDSmdiK1U6ExtUfY3w6tasmYNrrrFyzTVWHA7YscPgm2/MfPONmXXrzHz9tZk1a078q0ZF\n2V3B/KKLbLRvb6+xHq4iVVFSArt3G/z2m7N0XFpa/v132LevATk5RoW9uEsFBTk45xwHsbFW2rSx\nc+65DleHsTZtHDRp4qAuVd56LXjn5OQQGxvr2m7SpAnZ2dmEnTRm5qWXXuKNN95gxIgRtG7d+pTX\na9w4FIvFswWXIyLCq5ZoH6X8VN1zz7nf//zz9Rk1qnreo7rzExkJl156YvvoUVi7Fr76yvlYs8bE\n4sUmFi92FicsFujUCf7yF+ja1fl80UVUeXia/t58my/mp7gY9uyBXbtg92747Tf49dcTj927nZ3G\n/iwkBJo3N9GpEzRv7vzbr+jRvLmB2Wzg63OL1dT9qbEOaw5H+aq+UaNGMWLECO644w4uvvhiLr74\n4grPP3zYs+mrnF31j1U5nb5G+TkzmzeHAeW/jm/e7CA7O++Mr19T+enSxfkYMwZsNvj5ZxPffmtm\nwwYTGzea2bTJxA8/GLz2mvN4w3AQFWWnc2c7nTrZuOACZxtfmzb2UwZ1/b35ttrIz/HjsG+fwd69\nJvbsMdizx8S+fQZ79hjs2+fcV1FVtmE4aNnSQffuZYdXOR8OYmLCyMnxLD+HDlVnrrzDG/enoi8D\nXgvekZGR5OTkuLYPHDjgqho/cuQIv/zyC5deein16tXj8ssvZ/369acM3iJVURszsXmb2QwxMXZi\nYk7kwWqFbdtMbNhg4qefzGzcaGLDBjPp6WbS08s2+DVp4vwgbd36xPO55zqDu4at1S02G+TkGK6g\nXPq8d++J7QMHDBwO9/XR9eo5g3PHjlZatHDQqpWdFi0cf1RrO8c/n6pJpy5Vc1c3rwXvnj178uyz\nz5KUlMSmTZuIjIx0VZlbrVYmT57M8uXLadCgARs2bOBvf/ubt5IidVhtz8RWUywW6NDB2UHn+uud\nbfml7ecbNpj57bcTvXN37XIOpfnhB/fNUI0bh9GihZ2WLR2u55YtnR/KLVo4fw73vZrbOs9qdTax\nHDlikJtrcPiws7PXoUPOx8GDJx6l+w4dqjgwBwU573ePHs6JhVq1srueSwN148YKwLXFa8G7a9eu\nxMbGkpSUhGEYpKSkkJ6eTnh4OAMGDODuu+9mxIgRWCwW2rdvT//+/b2VFKnDfGUmttpgGHDeeQ7O\nO698Xu12Z8/eHTucvXhLg/r+/cHs3Glnxw4TmzdX/KkcFuYgIsJB06YOmjWz06xZ6c/ln8PDHQQH\nO+eGr6sf9HY7HDmCqxd1aa/q0ufjxw0Mwzl0yTDAZDrxKN02DAgOht9/r0durkFuLn88Ox9/HiJV\nEcNwdu5q2tQ5hCoiwkGrVieC8znnOJ8jIvx7KFWgMxzuGqN9kKftCGrj8m3Kj287OT/HjsHevc4q\n1P37DdfP+/Y5n0tLdVar5xE5KMhBUBB/PE4E9eBg5/4GDZxfDBo0cBAWxh/PjnL7Q0MdhIY6h9Kd\n/Bwa6pymsvRLQml+HA5np6r8fIP8fCgocD47tw0KC50BtjRInhwwoex+mw0KCqCw0Hneyc+l+wsK\nnNcuHep08GDlfk+eMAwHDRtCo0YO16NhQweNGkHDhs7g3LTpiUBd+vNZZzkwe9b31+sC+f+nOq/p\njmZYExG3wsOhfXs77dtXfIzdDrm5cPDgibG5pVWzpT/n5RmUlDirdUtKDI4fdw4dcj47twsKDIqL\nnQHVZjuzIGcYDurXdwbyoCDIywujoODMr1sVYWHO2ocuXexERDhrKCIinI9mzU48QkIcrt7YdjvY\n7cYfz86Hw+F8NG3aAJstj7POcn6JUcm47lLwFjmJr03o4utMJmjcGBo3dtCune2Mr1daQs7Lcwby\nss8nfi4ocJZuS59LS7t/3nY4oHFjOw0aOEvxzoczsJ+8r359Z14cjrLB8uRH6X6zGVdpv/RLwoln\n58+lNQH16lX5N+F2b0QEZGf7RWWpeJmCt8gf/GFCl0BnGM6AV6+eg2bNoKIg5ilnNaZnw0xF/Ikq\nXUT+MHdusNv98+a53y8iUlsUvEX+sHWr+3+HivaLiNQWfSqJ/KGiiVv8eUIXEQlMCt4if5gwwf3E\nLYE2oYuI+D8Fb5E/JCZaSU0tJCbGhsXiICbGRmqqOquJiO9R8BY5SWKilczMAvbuzSMzs6DCwJ2R\nYSEuLhSLBeLiQsnI0MANEak5+sQRqSQNKROR2qaSt0glaUiZiNQ2BW+RStKQMhGpbfq0EakkDSkT\nkdqm4C1SSRpSJiK1TcFbpJLKDilDQ8pEpMYpeItUQemQsuPHOeWQMjgxrKxFizANKxORaqFPEREv\n0rAyEfEGlbxFvEjDykTEGxS8RbxIw8pExBv0CSLiRRpWJiLeoOAt4kUaViYi3qDgLeJFlVmpTL3S\nRcRT+nQQ8bLEROtpe5arV7qIVIZK3iI+QL3SRaQyFLxFfIB6pYtIZeiTQcQHqFe6iFSGgreID6hM\nr3R1bBMR/deL+ABnp7RC5s0LZutWE9HRdsaPLynXWU0d20QEFLxFfIYnvdJP1bFNwVuk7lC1uYgf\nUcc2EQEFbxG/oo5tIgIK3iJ+pbLTrapzm0hg0n+yiB/xtGMbqHObSCBT8BbxM550bAN1bhMJZKo2\nFwlQ6twmErj0XywSoNS5TSRweTV4z5gxg2HDhpGUlMRPP/1U5rWvv/6aoUOHkpSUxIMPPojdrg8U\nkepUlVnbLBbUsU3ED3gteK9bt44dO3aQlpbG9OnTmT59epnXH374YebPn8/ixYvJz8/niy++8FZS\nROokT9cSL+3YlpVlxmY70bFNAVzEd3ntv3PNmjXEx8cDEBUVRW5uLnl5eYSFhQGQnp7u+rlJkyYc\nPnzYW0kRqbM0a5tIYPJa8M7JySE2Nta13aRJE7Kzs10Bu/T5wIEDfPnll4wfP/6U12vcOBSLxezR\ne0dEhFcx1b5J+fFt/p6frVsr2m/2+7yB/9+fP1N+fFtN5afG6sUcDke5fQcPHuTOO+8kJSWFxo0b\nn/L8w4cLPHqfiIhwsrOPVSmNvkj58W2BkJ/o6FCyssp/MY6OtpGdXf7/LiPDwty5J8aZT5jgfpy5\nLwiE+3My5ce3eSM/FX0Z8Fqbd2RkJDk5Oa7tAwcOEBER4drOy8vjjjvuYMKECfTq1ctbyRCR06hs\nx7YT7eOG2sdFaonXgnfPnj1ZtWoVAJs2bSIyMtJVVQ4wc+ZMbr75Zi6//HJvJUFEPFC2YxsVdmyD\nU7ePi0jN8drX5a5duxIbG0tSUhKGYZCSkkJ6ejrh4eH06tWLZcuWsWPHDpYuXQrAlVdeybBhw7yV\nHBE5hdKObc5qv4qbqDTxi4hv8Gpd16RJk8psd+jQwfXzxo0bvfnWIuIF0dH2CtrHy8/T4E9t4yL+\nRl+XRcRjnraPq21cxLsUvEXEY55O/KK2cRHv0tdgEakUTyZ+Udu4iHfpP0lEql1lFkUpnVe9RYsw\nzasu4iEFbxGpdmobF/EuBW8RqXZqGxfxLn29FRGv8EbbuIafiTip5C0itaaybeOqYhdxUvAWkVpT\nmXnVVcUucoKCt4jUGk/bxqFyVeylPdgtFtSDXQKS/qJFpFZ50jYOnk/NWlq9Xqq0eh3cfykQ8Ucq\neYuIX/C0il3V61IXKHiLiF/wtIq9Kj3YNUmM+Bv9lYqI3/Ckir2yK5+pil38kUreIhJQ1INd6gIF\nbxEJKGWr16n2HuyqXhdfoL8+EQk4pdXrERHhZGcXVHicerCLv1LJW0TqLPVgF3+l4C0idZY3erCr\nel1qgv6qRKROq84e7Kpel5qikreIyGl4q3pdpXSpKv2liIichrPUXMi8eSeWIx0/vvxypJWtXlcp\nXapKwVtExAPVPUHMqUrpCt5yOqo2FxGpJpWZIEarpMmZUPAWEakmlVni1F1p3N3+0ur1rCwzNtuJ\n6nUF8LpNwVtEpBolJlrJzCxg7948MjMLKqwCVyc4ORO6qyIitUCd4ORMKHiLiNQSdYKTqlK1uYiI\nD/N2JzhVr/snBW8RER9WmVXSqtYJzlAnOD+k4C0i4uNKO8EdP06Nd4JTCd036S6IiASI6u4Epw5w\nvkslbxGRAOLJUDVPq9c1TM13KXiLiNQxnlavV2WYmtrRa4aCt4hIHePpTHCeltChau3omu616hS8\nRUTqIE+q170xTK2y072qKt49rwbvGTNmMGzYMJKSkvjpp5/KvFZcXMwDDzzANddc480kiIhIFXlj\nrvbKltBVFe+e14L3unXr2LFjB2lpaUyfPp3p06eXef3JJ5+kY8eO3np7ERGpBtU9V3tl2tE1pK1i\nXgvea9asIT4+HoCoqChyc3PJy8tzvX7PPfe4XhcREf/mjXb0qlXF140SutdylpOTQ2xsrGu7SZMm\nZGdnExYWBkBYWBhHjhzx+HqNG4disZSf39ediIjwyiXWxyk/vk358W3KT80ZNcr5cDID9csd8/DD\n8I9/lD936lRzubzFxMCGDeWPjYkxyhz73HPu0/P88/VPSo/T4sUwYwZs3uy8fnIyJCVVnKfKqqn7\nU2NfSxwOxxmdf/hwgUfHRUSEk5197Izey5coP75N+fFtyo/v6d8fUlMtf0wkYyY62sb48SX0728l\nO7vssWPHlp0kptTddxeSnX2iRL95cxhglDtu82YH2dknanz/POnMhg3OLxJHj7pvx8/IsDB37okJ\nbyZMKD/hzcm8cX8q+jLgteAdGRlJTk6Oa/vAgQNERER46+1ERMRPlK6m5gx2FRfMPJ0xztOV1yqz\n6pqvzy7ntTbvnj17smrVKgA2bdpEZGSkq8pcRETEE9U5pM3bneVqcty6196ha9euxMbGkpSUhGEY\npKSkkJ6eTnh4OAMGDGDcuHHs37+f//3vfwwfPpyhQ4dy1VVXeSs5IiISoKq7hA6+P/+74TjTxuga\n4mk7QiC0CZ1M+fFtyo9vU358W03n58+BtpS7XvFxcaFuA31MjI3MzIJKH1dVFbV5a4Y1ERGpEyoz\n6Yw3quKrU+AOghMREfmT0s5ynhxX3VXx1UnBW0RExA1PAv2ECSVuq+Ldzf9enVRtLiIiUkVlq+I5\nZVV8dVLJW0RE5Ax4Om69OqnkLSIi4mcUvEVERPyMgreIiIifUfAWERHxMwreIiIifkbBW0RExM8o\neIuIiPgZBW8RERE/o+AtIiLiZ/xmSVARERFxUslbRETEzyh4i4iI+BkFbxERET+j4C0iIuJnFLxF\nRET8jIK3iIiIn7HUdgKq04wZM/jxxx8xDIPk5GQ6d+5c20mqsrVr1zJ+/HguuOACAKKjo5k6dWot\np6rytm7dypgxY7jlllu46aab2LdvH/fffz82m42IiAieeuopgoODazuZHvtzfiZPnsymTZs466yz\nABg5ciR9+vSp3URWwpNPPsl3332H1Wpl9OjRXHjhhX59f/6cn08//dRv709hYSGTJ0/m4MGDFBcX\nM2bMGDp06OC398ddflatWuW396dUUVERV155JWPGjKFHjx41dn8CJnivW7eOHTt2kJaWxvbt20lO\nTiYtLa22k3VGunXrxvz582s7GVVWUFDA448/To8ePVz75s+fzw033MCgQYN4+umnWbp0KTfccEMt\nptJz7vIDcO+999K3b99aSlXVff311/zyyy+kpaVx+PBhEhMT6dGjh9/eH3f56d69u9/en88++4xO\nnTpxxx13sGfPHm677Ta6du3qt/fHXX7+8pe/+O39KfXCCy/QqFEjoGY/3wKm2nzNmjXEx8cDEBUV\nRW5uLnl5ebWcqrotODiYl19+mcjISNe+tWvX0r9/fwD69u3LmjVrait5leYuP/7s0ksvZd68eQA0\nbNiQwsJCv74/7vJjs9lqOVVVN3jwYO644w4A9u3bR/Pmzf36/rjLj7/bvn0727Ztc9UW1OT9CZjg\nnZOTQ+PGjV3bTZo0ITs7uxZTdOa2bdvGnXfeyT/+8Q++/PLL2k5OpVksFurVq1dmX2FhoasaqWnT\npn51j9zlB2DRokWMGDGCe+65h0OHDtVCyqrGbDYTGhoKwNKlS7n88sv9+v64y4/ZbPbb+1MqKSmJ\nSZMmkZyc7Nf3p9TJ+QH//f8BmDVrFpMnT3Zt1+T9CZhq8z/z91lfzzvvPMaOHcugQYPYtWsXI0aM\n4KOPPvKb9i1P+Ps9Arj66qs566yz6NixIy+99BLPPfccDz/8cG0nq1JWr17N0qVLWbBgAVdccYVr\nv7/en5Pzs3HjRr+/P+o/+1YAAAUYSURBVIsXLyYrK4v77ruvzD3x1/tzcn6Sk5P99v4sW7aMLl26\n0Lp1a7eve/v+BEzJOzIykpycHNf2gQMHiIiIqMUUnZnmzZszePBgDMOgTZs2NGvWjN9//722k3XG\nQkNDKSoqAuD333/3+yroHj160LFjRwD69evH1q1bazlFlfPFF1/w4osv8vLLLxMeHu739+fP+fHn\n+7Nx40b27dsHQMeOHbHZbDRo0MBv74+7/ERHR/vt/cnMzOSTTz5h6NChLFmyhH/96181+v8TMMG7\nZ8+erFq1CoBNmzYRGRlJWFhYLaeq6pYvX86rr74KQHZ2NgcPHgyINqLLLrvMdZ8++ugjevfuXcsp\nOjP//Oc/2bVrF+Bs7yodHeAPjh07xpNPPklqaqqrt68/3x93+fHn+/Ptt9+yYMECwNksWFBQ4Nf3\nx11+Hn74Yb+9P3PnzuXdd9/lnXfe4frrr2fMmDE1en8CalWx2bNn8+2332IYBikpKXTo0KG2k1Rl\neXl5TJo0iaNHj3L8+HHGjh1LXFxcbSerUjZu3MisWbPYs2cPFouF5s2bM3v2bCZPnkxxcTEtW7bk\niSeeICgoqLaT6hF3+bnpppt46aWXqF+/PqGhoTzxxBM0bdq0tpPqkbS0NJ599lnatm3r2jdz5kym\nTJnil/fHXX6uueYaFi1a5Jf3p6ioiIceeoh9+/ZRVFTE2LFj6dSpEw888IBf3h93+QkNDeWpp57y\ny/tzsmeffZZWrVrRq1evGrs/ARW8RURE6oKAqTYXERGpKxS8RURE/IyCt4iIiJ9R8BYREfEzCt4i\nIiJ+JmBnWBMR2L17NwkJCfzlL38psz8uLo7bb7/9jK+/du1a5s6dy9tvv33G1xIRzyl4iwS4Jk2a\nsHDhwtpOhohUIwVvkToqJiaGMWPGsHbtWvLz85k5cybR0dH8+OOPzJw5E4vFgmEYPPzww7Rr147f\nfvuNqVOnYrfbCQkJ4YknngDAbreTkpJCVlYWwcHBpKamAjBx4kSOHj2K1Wqlb9++3HXXXbWZXZGA\nojZvkTrKZrNxwQUXsHDhQv7xj3+41o6///77efDBB1m4cCG33norjz76KAApKSmMHDmSN998k2uv\nvZYVK1YAzmUR//nPf/LOO+9gsVj473//y1dffYXVauWtt95i8eLFhIaGYrfbay2vIoFGJW+RAHfo\n0CGGDx9eZt99990HQK9evQDo2rUrr776KkePHuXgwYN07twZgG7dunHvvfcC8NNPP9GtWzcAhgwZ\nAjjbvM8//3yaNWsGwNlnn83Ro0fp168f8+fPZ/z48cTFxXH99ddjMqmsIFJdFLxFAtyp2rxPnh3Z\nMAwMw6jwdcBt6dlsNpfb17RpU9577z2+//57PvnkE6699loyMjLcrocuIpWnr8IiddjXX38NwHff\nfUf79u0JDw8nIiKCH3/8EYA1a9bQpUsXwFk6/+KLLwD48MMPefrppyu87n//+18yMzO5+OKLuf/+\n+wkNDeXgwYNezo1I3aGSt0iAc1dtfs455wCwefNm3n77bXJzc5k1axYAs2bNYubMmZjNZkwmE488\n8ggAU6dOZerUqbz11ltYLBZmzJjBzp073b5n27ZtmTx5Mq+88gpms/n/27tjKgBiEIiCFHERAZjA\nvwP8nIor9mXGQaofaKiZqXvvf4+Ex7gqBo/q7trdOscfHtJYmwNAGJM3AIQxeQNAGPEGgDDiDQBh\nxBsAwog3AIQRbwAI8wHF85TcH7VQggAAAABJRU5ErkJggg==\n",
-      "text/plain": [
-       "<Figure size 576x396 with 1 Axes>"
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aibHm5ydp6CW",
+        "colab_type": "text"
+      },
+      "source": [
+        "\n",
+        "## A. 環境を準備する\n",
+        "\n",
+        "必要なライブラリのインストール、インポートを行います。"
       ]
-     },
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "acc = history.history['acc']\n",
-    "val_acc = history.history['val_acc']\n",
-    "loss = history.history['loss']\n",
-    "val_loss = history.history['val_loss']\n",
-    "\n",
-    "epochs = range(1, len(acc) + 1)\n",
-    "\n",
-    "# \"bo\" is for \"blue dot\"\n",
-    "plt.plot(epochs, loss, 'bo', label='Training loss')\n",
-    "# b is for \"solid blue line\"\n",
-    "plt.plot(epochs, val_loss, 'b', label='Validation loss')\n",
-    "plt.title('Training and validation loss')\n",
-    "plt.xlabel('Epochs')\n",
-    "plt.ylabel('Loss')\n",
-    "plt.legend()\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 376
     },
-    "colab_type": "code",
-    "executionInfo": {
-     "elapsed": 988,
-     "status": "ok",
-     "timestamp": 1553304561340,
-     "user": {
-      "displayName": "Tomo Masuda",
-      "photoUrl": "https://lh5.googleusercontent.com/-xWkmNceNhGQ/AAAAAAAAAAI/AAAAAAAAB60/DG3sdpAeNVE/s64/photo.jpg",
-      "userId": "04052575624663243173"
-     },
-     "user_tz": -540
-    },
-    "id": "uWTEWhHAxrPq",
-    "outputId": "26294c2a-3b11-4b7a-adaf-bb012024405f"
-   },
-   "outputs": [
     {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAe8AAAFnCAYAAACPasF4AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi40LCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcv7US4rQAAIABJREFUeJzt3Xl4U1XixvHvTdKF0gIttCAIiECB\nwqAiMlZwKvs+/qqD4oaKioqMoCgCI6I4rIoD6Ki4KyiLSkcdWQQRRUUQUEcQBKqssrSlLKULbZLf\nH6GB0pSmpWlym/fzPH2a3CQ35+QW3pxzzz3HcDqdTkRERMQ0LP4ugIiIiJSNwltERMRkFN4iIiIm\no/AWERExGYW3iIiIySi8RURETEbhLVXG+PHj6dWrF7169aJ169Z07tzZfT8rK6tM++rVqxfp6enn\nfM706dOZN2/e+RS5wt1xxx0sWrSoQvbVokULDhw4wPLlyxkzZsx5vd/ChQvdt735bEXk3Gz+LoBI\nRXnqqafct7t06cK0adNo3759ufa1dOnSUp8zcuTIcu3bbLp370737t3L/fq0tDRee+01brjhBsC7\nz1ZEzk0tbwkat912G//617/o3bs3GzduJD09nbvuuotevXrRpUsX3nzzTfdzC1uda9eu5cYbb2T6\n9On07t2bLl26sG7dOgBGjx7Niy++CLi+LMyfP5+//e1vdOrUiSlTprj39fLLL5OYmMj111/Pu+++\nS5cuXTyW7/3336d379706NGDW265hX379gGwaNEiHnzwQcaOHUvPnj3p06cP27dvB2DPnj0MGDCA\nbt26MXLkSOx2e7H9fvnll/Tv37/ItmuvvZavvvrqnJ9BoUWLFnHHHXeU+n6ff/45/fv3p2fPnlx3\n3XVs2bIFgIEDB/LHH3/Qq1cvTp486f5sAd555x369OlDr169uP/++zl8+LD7s501axZ33nknnTt3\n5s477yQnJ6dY2XJychgxYgQ9e/akS5cuTJ061f3Ynj17uOWWW+jevTvXX389mzdvPuf2Ll26sH79\nevfrC+/v3buXTp06MWnSJG699dZz1hXglVdeoWvXrvTs2ZPJkydjt9vp2LEjP//8s/s5c+fOZejQ\nocXqI+IthbcElU2bNvHpp5/Srl07XnrpJS688EKWLl3K22+/zfTp09m/f3+x1/zyyy9ccsklLFmy\nhJtvvpmXXnrJ476///57FixYwIcffsjcuXM5cOAA27dv57XXXuOjjz7ivffeK7HVmZGRwYQJE3jz\nzTf57LPPaNSokfuLAcBXX33FzTffzLJly/jzn//M22+/DcCzzz5LYmIiK1as4Pbbb2fjxo3F9p2Y\nmMiBAwfYs2cP4AqvAwcOcNVVV3n9GRQq6f0KCgoYPXo0Tz/9NMuWLSsSpJMmTeKCCy5g6dKlhIaG\nuvf1448/8vrrrzNnzhyWLl1K/fr1mT59uvvxpUuX8q9//Yvly5dz+PBhli9fXqw88+bN48SJEyxd\nupSUlBQWLVrkDuBx48bRt29fli9fzv3338+oUaPOuf1cjhw5QqtWrZg7d+4567p+/Xo++OADPvro\nIz755BM2bNjAZ599Ru/evfnvf//r3t/y5cvp27dvqe8rUhKFtwSVpKQkLBbXn/3jjz/OuHHjAGjY\nsCGxsbHs3bu32GuqV69Ot27dAGjdujV//PGHx333798fq9VK3bp1qV27Nvv37+f777+nQ4cOxMXF\nERYWxvXXX+/xtbVr12bDhg3Uq1cPgPbt27vDFqBp06a0adMGgISEBHfArl+/nj59+gDQtm1bLr74\n4mL7Dg0NpXPnzqxcuRKAFStW0K1bN2w2m9efQaGS3s9ms/Htt99y6aWXeiy/J6tWraJnz57Url0b\ngAEDBvDNN9+4H09KSqJWrVrYbDbi4+M9fqkYPHgwL774IoZhULNmTZo3b87evXvJy8tj7dq19OvX\nD4CuXbuycOHCEreXJj8/333q4Fx1/eqrr0hKSiIyMpLQ0FDmzJlDjx496Nu3L4sXL8bhcHDkyBE2\nbdpE586dS31fkZLonLcElZo1a7pv//zzz+6WpsViIS0tDYfDUew1UVFR7tsWi8XjcwAiIyPdt61W\nK3a7nWPHjhV5z7p163p8rd1uZ9asWaxcuRK73c6JEydo0qSJxzIU7hvg6NGjRd63Ro0aHvffs2dP\n3nnnHW6//XZWrFjh7rL19jModK73mzNnDikpKZw8eZKTJ09iGEaJ+wE4fPgwcXFxRfaVkZFRap3P\ntHPnTqZMmcJvv/2GxWLhwIEDXHfddRw5cgSHw+Heh2EYVK9enYMHD3rcXhqr1Vqk3iXVNTMzs0id\nqlWrBsBll11GSEgI69at48CBA3Tq1ImIiIhS31ekJGp5S9B69NFH6dmzJ8uWLWPp0qVER0dX+HtE\nRkaSnZ3tvn/o0CGPz1u8eDErV65k7ty5LFu2jAcffNCr/deoUaPISPrCc8Znu/rqq9m6dSs7d+5k\n586dXHnllUDZP4OS3m/jxo28+uqrvPTSSyxbtox//vOfpZa9Tp06HDlyxH3/yJEj1KlTp9TXnWnC\nhAk0b96cJUuWsHTpUlq2bAlAdHQ0hmGQmZkJgNPpZNeuXSVudzqdxb6YHT161ON7nquu0dHR7n2D\nK8wL7/ft25elS5eydOlSd++FSHkpvCVoZWRk0KZNGwzDICUlhZycnCJBWxHatm3L2rVrOXz4MCdP\nnuQ///lPiWVp0KABMTExZGZmsmTJEk6cOFHq/i+99FL3ueCNGzeye/duj88LDQ2lU6dOPPPMM3Tt\n2hWr1ep+37J8BiW93+HDh6lduzb169cnJyeHlJQUsrOzcTqd2Gw2srOzKSgoKLKva665huXLl7vD\nbf78+SQlJZVa5zNlZGTQqlUrrFYr33zzDbt27SI7O5vQ0FA6duxISkoKAKtXr2bIkCElbjcMg9jY\nWLZu3Qq4vkzl5eV5fM9z1bVLly6sXLmSo0ePUlBQwAMPPMDXX38NQL9+/VixYgU//PBDmespcjaF\ntwSt4cOH88ADD9C/f3+ys7O58cYbGTduXIkBWB5t27YlOTmZ5ORkBg0aVOJ5zn79+nHkyBG6d+/O\nyJEjGTFiBAcOHCgyat2TRx99lC+++IJu3brx7rvvctVVV5X43J49e7JixQp69+7t3lbWz6Ck97v6\n6quJi4ujW7duDB48mNtvv52oqCgefPBBWrRoQc2aNenYsWOR8QJt27ZlyJAh3HLLLfTq1Yvjx4/z\n0EMPnbO+Z7v//vuZOnUq/fr1Y926dQwbNoznn3+eDRs2MHHiRL744gu6du3KjBkzePbZZwFK3D50\n6FDeeust+vXrR2pqKs2aNfP4nueq66WXXspdd93F//3f/9G3b18SEhLc59dbtGhBrVq16NSpE+Hh\n4WWqp8jZDK3nLeJbTqfTfU501apVzJgxo8QWuFRt99xzD7feeqta3nLe1PIW8aHDhw9z5ZVXsm/f\nPpxOJ0uWLHGPUpbgsmHDBvbt28fVV1/t76JIFaDR5iI+FBMTw4gRI7jjjjswDIOLL77Yq+uKpWoZ\nM2YMGzdu5JlnnnFfqihyPtRtLiIiYjL6CigiImIyCm8RERGTMc0577S04149Lzo6gszMir1W159U\nn8Cm+gQ21SewqT6li42N8ri9yrW8bTarv4tQoVSfwKb6BDbVJ7CpPuVX5cJbRESkqlN4i4iImIzC\nW0RExGQU3iIiIiaj8BYRETEZhbeIiIjJKLxFRERMxjSTtASi55//F7/+uoXDhzPIzc2lfv0G1KhR\nk0mTnin1tYsXf0L16pEkJXle33nmzOkMGDCQ2NiWFV1sERExuaAK75QUGzNmhLJtm4X4eAcjRpwk\nObmg3Pv7+98fAlxB/NtvqQwbNsLr1/bp0/+cjw8fPrLc5RIRkcpzOlsgPj7ivLPFG0ET3ikpNu69\nt5r7/pYt1lP3cyr8Q964cT3z588lOzubYcMe4ocfNrBq1ec4HA4SEzsyePAQXn99NrVq1aJJk6Ys\nWrQQw7Cwa9fvXHNNVwYPHsKwYUN4+OFRzJ//NYcOZbB79y727dvLgw+OJDGxI3PnvsWKFZ9Rv34D\nCgoKGDjwFtq1a+8uw/ffr+W1114mJCSEqKgoJkyYQkhICDNmPMsvv2zCarXy6KNjuPjiZh63iYgE\nO28afJWZLWcKmvCeMSPU4/aZM0N98gGnpu5g3rxFhIaG8sMPG3jxxdewWCzccMO13HjjzUWe+8sv\nm3nvvQ9xOBwMGNCfwYOHFHn80KGDPPvsLL777ls++uhDWrduw6JF7zNv3oecOHGCgQOvY+DAW4q8\n5vjx44wf/0/q12/A008/wdq1awgLC+PQoYO88spb/PjjRj7/fDkZGRnFtim8RaSq8rYH1ttQruxs\nKRQ04b1tm+exeSVtP1/NmjUnNNR1UMPDwxk2bAhWq5UjR45w7NixIs9t0aIl4eHhJe6rbdtLAYiL\niyMrK4u9e/dw8cVNCQsLJywsnFatWhd7Ta1atZg69Z/Y7Xb++GMfl19+BZmZh/nTny4B4NJL23Hp\npe149923i20TEamKytJK9jaUKztbCgXNaPP4eEeZtp+vkJAQAA4c2M+CBe8yffrzvPDCK9SrV6/Y\nc63Wc09mf+bjTqcTpxMsltOHzjCKv2by5Kd56KFRvPDCK3Tq9BcALBYrTmfR+nraJiISKFJSbCQl\nRXDBBZEkJUWQkuK5zenN884VyGfzNpQrO1sKBU14jxhx0uP24cM9b68oR44cITo6moiICH79dSsH\nDhwgPz//vPZ5wQUX8NtvqRQUFJCZmcnWrVuKPefEiSzq1q3H8ePH2bhxA/n5+bRqlcDGjesB2LZt\nK9OnT/W4TUQkEBS2lLdssWK3G+6W8tnB7O3zytJK9jaU/ZUtQRPeyckFzJ6dQ0KCHZvNSUKCndmz\nfTugAKB583iqVYvg/vsH8/nnn3Httdedd0DGxNSme/de3HPPIGbOfJaEhNbFWu/XXTeA+++/i2nT\nJnLLLYOYO/ctLrywEY0bN2Ho0LuZMeNZ/u//rufSS9sV2yYiUh5lbSXbbJzzed62lL19Xllayd6G\nctFsodKyxXA6nU6fvkMFSUs77tXzYmOjvH6uGZRUn8WLP6F7915YrVYGDRrIc889T1xcXT+UsGyC\n5fiYleoT2PxRn/IO8Cp0dpB5+zyACy6IxG4vfl7QZnPyxx9ZZX5eWd678PkzZ56u+/Dh574EzBfH\nJzY2yuP2oGl5VzUZGRkMGXI79903mB49epkiuEUkcHjTSva2OxoqvpUM3reUvX1eWXtgk5MLWLUq\nmz/+yGLVqmyft6bLQi3vAKf6BDbVJ7CpPp552wJNSopgy5biA2oTEuysWpVdZFtFt5LLUs6ytqh9\nRS1vEREpl4ocde2LAV5lOe/sbUvZX2Oa/EnhLSIS4Lwd4FXRo659McCrrKOzve26DuQubl9QeIuI\nBLCigUyFnHf2xWVQ5WslV97o7KpG4S0i4if+mlikfJdBVdwAr8Ln5ecTFK1kX1B4n4d7772z2AQp\nL7/8AvPmzfX4/I0b1/P446MAGD364WKPf/jhAl5/fXaJ77djx3Z2794FwPjxY8jLyy1v0UXER8py\nrbO/JhYpSygHW3e0WSi8z0P37j1ZuXJ5kW2rVq2kW7cepb52ypTnyvx+X365kj17dgPw1FOTCQsr\neT50EalY/rq0yhfnnUGhbHZBszCJL3Tt2oP777+LoUMfBGDr1i3ExsYSGxvncUnOM/Xt25VPP/2c\n9evXMWvWdGJialO7dh33Ep8TJz5JWtoh8vPzGDToburVu4CPPlrEl1+uJDo6mieeGMM77ywgK+s4\nkydPID8/H4vFwujR4zAMg4kTn6R+/Qbs2LGd+PgWjB49rsj7f/bZEj74YAFWq4WLLmrKY4/9g4KC\nAv75z/EcPLif0NAwHn/8KaKjY4pti42Nq7TPWCQQ+GKFqbJ0cXu6DKqkQIacMk0sIuZUZcL7ySfD\n+OQTGxYLOBzVK2Sf/fsX8OSTeSU+Hh0dQ/36Dfjll00kJLRh5crldO/eC/C8JGdERESxfcye/QLj\nxj1N8+bxPPLIg9Sv34Djx4/RocOV9O7dj9zcIwwdOow33pjLn/+cyDXXdCUhoY379a+99jL9+l1L\n1649+OKLFbzxxivcdde9/PrrFp56ahLR0TEkJ/fh+PHjREWdvl4wJyeH6dOfJyoqigceuIfU1B38\n8ssmateuzZNPTmTFimV8/fVX2Gy2YtuSk/9WIZ+vSCDwZgYxX6wwFR/v8HgNtacu7tOBbCU+3n7O\nQE5OLlBYB4EqE97+0r17Lz7/fDkJCW345puveOmlNwDPS3J6Cu/9+/fTvHk84FqSMy8vj6ioGmzZ\nspmPP15EaGgIx44dLfH9f/11C/fdNwyAdu3a89ZbrwHQoEFDateuA0CdOrGcOJFVJLxr1KjBmDEj\nAdi163eOHj3Cr79upX37KwDo1q0nAM8+O6XYNpGqwtsWdVkurfImkKHsLerk5IJTk4BkF3tcgk+V\nCe8nn8zjySfzTv1xn6i0901K6sw777xB9+49adiwETVq1ABcS3I+88wMLrqoCc89V/JCJGcu7Vk4\n2d3y5Us5duwY//73a4SE2ElOvu4cJTDcr8vPL8AwXPs7e6GSMyfSy8/P57nnpvHWW+9Ru3YdRo0a\nceo1FhyOohPuedomEuhOt6YhPj6ixPm4vW1RexvK6uKWyqIBa+cpIqI6TZs255133nR3mYPnJTk9\nqVMnlt27d+J0Ovnhhw2AaxnRCy6oj8ViYfny5e7XGoaB3W4v8vozl/T88ccNtGzZqtQyZ2efwGq1\nUrt2HQ4ePMDWrVsoKCigZcsENm78HoBvvlnNO++84XGbSCAry3XRZrm0SuRsCu8K0L17L77/fi2d\nOv3Fvc3TkpwZGenFXjtkyFAef/wxHnvsIffiItdc04Vvv13N8OH3U61aNeLi4njzzVe55JLLmDHj\nGdavX+d+/d1338fSpYt58MH7WLz4v9x1172llrdmzVpcccWfufvuQbz55qvcfPNtzJr1HF279iAn\nJ4dhw4awcOE8evfuR7duPYttE/GXir4uWpdWiVlpYZIAp/oENtWn8ni7+IQvFr4IFIF8fMpD9fFu\nn56o5S0ifuXtpCa+uC46GBe0kKqhygxYExHz8Xa0N/jmumjQpVViTmp5i4jf+P78tBa+kKpJ4S0i\nPuFNd3hZJjUpz9SfWvhCqiqFt4hUOG/n+Nb5aZHyUXiLSJlU5OVaZWlNgy7DEimkAWsi4rWKnk5U\ns4yJlI/CW0S8VtHTiYJGe4uUh7rNRcRrFT2dqIiUj8JbRNznsW02zjlRii+mExWRslO3uUiQK8tE\nKeVZxlJEKp5a3iJVWEUv5KEWtUhgUMtbpIqq6JHhhdSiFvE/tbxFTMafC3mISGBQeIuYiLczl4FG\nhotUZQpvkQBR0eentZCHSNWlc94iAcAX56fLMzI8NjaKtLTsctRARCqTWt4iAcAX56c1Mlyk6lJ4\ni/hYRS6NqYU8RAQU3iI+VdFLY6o1LSKg8BbxKV8sjanWtIgovEV8qCxLY6pFLSLeUniLlENFL+QB\nalGLiPcU3iJlVPQ8NuecKEUToIiILyi8RcpIC3mIiL9pkhaRM6Sk2JgxI5Rt2yzExzsYMeJksaDV\nQh4i4m9qeYucUtGXdYmI+IrCW+QUX1zWJSLiCz4N70mTJnHjjTcycOBA/ve//xV5bMWKFVx//fXc\ndNNNzJ0715fFkCDn7RKa5busSwt5iEjl89k573Xr1rFr1y4WLFhAamoqY8eOZcGCBQA4HA6efvpp\nUlJSqFWrFvfccw/dunWjXr16viqOBClvF/wAV7f3li3WYvso6bIuLeQhIv7is5b3mjVr6NatGwBN\nmzbl6NGjZGVlAZCZmUmNGjWIiYnBYrFw5ZVX8u233/qqKBLEyjIyXN3hImIWPgvv9PR0oqOj3fdj\nYmJIS0tz3z5x4gQ7d+4kPz+ftWvXkp6e7quiSBAry8hwXdYlImZRaZeKOZ1O923DMJgyZQpjx44l\nKiqKCy+8sNTXR0dHYLMV79L0JDY2qtzlDESqj2fz58OkSfDLL5CQAGPHwsCBRZ+TkAA//1z8tQkJ\nhsdyDBni+nGxAsXXwz6bjk9gU30Cm+pTPj4L77i4uCKt6UOHDhEbG+u+36FDB9577z0Apk+fToMG\nDc65v8xM784rus5BHi9HiQOT6uPZ2eeyf/4ZbroJjh0r2lIeNqzo8wo98EAOaWnn36LW8Qlsqk9g\nU32826cnPus279ixI8uWLQNg8+bNxMXFERkZ6X787rvvJiMjg+zsbL744gsSExN9VRSpgrw9l62u\ncBGpinzW8m7Xrh2tW7dm4MCBGIbB+PHjWbRoEVFRUXTv3p0bbriBwYMHYxgGQ4YMISYmxldFkSqo\nrOeyFdYiUpX49Jz3I488UuR+y5Yt3bd79OhBjx49fPn2UoWV5bIuEZGqRjOsScDxZlIVXdYlIsFM\nC5NIQPF2UhXX7Rxmzjy9iMjw4cUXERERqYoU3hJQzjUQ7exg1rlsEQlWCm8JKGVdblMCT14e7N1r\nsGuXhV27LOTmQlQU1KjhJDLSSY0aTqKiICrKdTsiAiweDq/dDrm5rv3l5Rmnbhvk5UFurnFqu+t2\n0cdO365eHapXDyEuzklsrJO6dR3ExTmpXt37+uTkwJEjhvsnJwcKCsBuN7DbweEovM8Z9w3AVcea\nNV31rFkTatZ03Q8LO/f7ZWYaHD5suH8X3s7Ph8zMsLM+A6PI51T4mGGA1erEasXDz+ntYWGnj03h\ncYqKKvw5fb96dTAMJw6HgdPpqueZv8+8Xa0a1KrlpFYtJ+HhZfwDEq8ovCWgaCBa5bDb4dgxOHrU\n4Ngxg6NHXT9hYZCbayMkxEloKISGQkgIhIU5CQnh1DYnFgvs3386oHfvtrBrl+v+/v0GTqfhdVkM\nwxUSERFO8vNPh1JhAJ6/4ulRvbqTuDgncXGuMK9d20lursGRI6eDOjPT9Znk5lZUOc4oUXhhoDup\nUcMVvJmZrvfMzi7t/Tz3TlksrqAMD3cdO6fT9QXD4XD9Lijg1G1O3a74enlSrZqrntHRrt+uUHeF\ne926kJUV6g7/ol8KTn9JAIiMdBIT4/qJji762/XFwvsyFX4OISG+qXNlUHhLpUhJsTFjRijbtkF8\nfAQjRng+Pz1ixEmPk6poINppDgfs2+cKyqwsyM52/Yd/4kThbc66bxQL6qysc/1PV/qscp4YhpP6\n9Z0kJtpp3NhJo0YOGjd2EBEBx49DVpbB8eOushw/bpzxA8eOucrpapW6Wqbh4Z5/h4a6AiEszPWl\nIjycs24XPgY1akSwfXsOhw4ZHDpkcPCgxX370CGD77+3Fgsxw3C1kmvVclK/vsMdPIUtyYiIklu0\nNpvri4311PdPV30Njh4t/kXp6FFXWO/caRASArVrO2nWzOEOJE8hddFFEeTknHB/FoWfS3g42Mr4\nv3lhMObklHRsTpf/+HHX35Pr83H1lFgsp28bRtGfwt6Kwi9AmZkGf/xhYetWPHyxO0c3hJdCQ09/\nRtWqub4M5efDyZMGJ0/CyZOQn3/6tt3uKkNMjIMGDZxceKGDCy8s+rtBA1dvzZlfCpxOOHECd53O\n7JE5cgTq14fk5LJ9kSgvhbf4XFlW9tJAtNNyciA11cKOHRa2bz/9OzXVQk5O2f93KGzpNW7soFat\nol25hY/VqRNOZmbuqf/kTv9nd/btggKoV+90QF90kes/u3N1B/tDbCwkJJT8t2O3Q0aGQXq6QUSE\n89Tn4rkbPxDExkJaWsX0Qrm61SEy0tWqrVfPWfqLzlNhj09hqNts1Tl6NNv9ZQBcPQhnfzEA1xeJ\nzEyDjAzD3Utx5u3Dhw327bOQl+f6glfYWxQS4uppOd2b5PptGK7eox07LPz8s+ept8PCnDRo4MRq\ndbpDOj//3P/2rr7aIDbW95+l4Txz0vEA5u2Uc5puL/AkJUV47ApPSLCzapW5l9OsiOOTleU6p791\nq4WtW61s3+4K6T17inc/R0Q4adrUQfPmrsAsPGccEXH6d/Xqhb+LbrN6sTRAVfh7O5PqE9gCoT5O\np+sL3L59Bnv2WNi3z2DvXgt7957+DVCzJkV6YAp/Ck8HREc7ad8+gpiYypkeVS1v8TkNQnPJyYHt\n2wtD2sKvv1rZutXCnj3FP4e4OAdXXWWnWTNXUBf+1K/vDNhWoYgZGQbUqeOkTh0nl1xyfr0arp6R\nCipYKRTe4nNmG4R26JBBWlrR87GF5/6yss48D+ga+JObW+3UICDDPRDm7J+8PIO9e4u3pOPiHFx9\ndQGtWjlo0cJBixZ2WrRwULOmnyovIqag8BafC+RBaAUF8MsvFr7/3ur+8dQSPjfXPyPPg5hc20JC\nIDHRFcwtW7p+WrSwoyn9RaQ8FN5yXk6PIncNLvM0irzoIDQr8fF2vw1CO3wYNmw4HdQ//GAtcmlO\nTIyDHj0KaNjQcera19PXIxde93rm/caNozh8+HiRgTUiIr6m8JZyK+so8uTkglMDVCpvkJrDAevX\nW/jkkxBWrrSyffvp7nvDcNKypYP27e1ccYWdDh3sNGniLFMIh4Z6NxBMRKQiKbyl3MoylWllstth\n7Vorn3xi49NPbRw44OoGr17dSVJSAVdc4Qrryy+3U6OG34opIlJuCm8pt0AaRZ6fD998Y+W//7Wx\neLGN9HRXGaKjndx880n69Svg6qvtAXcdsohIeSi8pdz8PYr8+HFXYC9damPJkhAyM1393XXqOBg0\n6CT9+xdw1VV2U0+BKCLiicJbyq2yR5Hn5bkGm331lZWvvrLxww8W9zSH9eo5uPvufPr1K+DPf7br\nPLSIVGkKbyk3X09l6nDApk0Wd1ivXWt1TwtqtTpp1851jXSXLgW0b+/Q5CUiEjQU3nJefLGm9nff\nWXn99RBWr7Zy+PDpRG7Vys7VV9v5y18KSEy0E+V51kARkSpP4S0BY80aK88+G8rq1a4/ywYNHNx0\nUz5/+UsBnTrZqVvXFNPwi4j4nMJb/O6bb1yh/c03rj/Ha64pYOTIk3ToYNfEJyIiHugsoRSTkmIj\nKSmCCy6IJCkpgpSUiv+O53R19gUQAAAfkUlEQVTC6tVWrr22GsnJEXzzjY0uXQr49NMTLFyYw5//\nrOAWESmJWt5SRFlmTSsPpxO+/NLV0l671vXn161bASNH5nH55YG5UImISKBReEsRvpo1LTcXVqyw\n8dpr8O23EQD06OEK7csuU2iLiJSFwluKqMhZ0/Lz4auvrKSkhLB4sY2sLFc/eK9e+YwcefK8184V\nEQlWCm8p4nxnTbPbXZd6paTY+O9/be5LvRo2dHDnnSe5554w6tXLrdAyi4gEG4W3FFGeWdOcTti4\n0cJ//hPCRx+dXggkNtbB3XefJDk5n/btHRgGxMaGkZbms+KLiAQFhbcUUZZZ05xOWLrUxoQJYaSm\nugK7Vi0nt97qev5VV2maUhERX1B4SzHezJq2Y4fBP/4Rzhdf2LDZnFx3XT7XX59PUpKdUM9j3kRE\npIIovKVMsrJg+vQwXnklhPx8g2uuKWDixDyaN9fgMxGRyqLwFq84nfDBB64u8oMHLTRq5GDChFx6\n9y7QZCoiIpVM4S2l+vlnC2PGhLFunY3wcCejRuXxwAMnqVZ8XJuIiFQChbeU6PBhmDw5jHfeCcHp\nNOjXL5+nnsqjYUMtECIi4k+a2zyIeDtnudMJ8+fbSEyM5O23Q2ne3MH772fzxhu5Cm4RkQCglneQ\n8HbO8vR0g0ceCWPx4hAiI51MmJDLXXflExLih0KLiIhHankHiXPNWV5o6VIrf/lLBIsXh9CxYwFf\nfnmC++5TcIuIBBq1vIPEueYsP34cxo0L4733QgkLc7W2hwzJx6KvdiIiAUnhHSRKmrO8QQMHnTtX\nZ/duC3/6k51//zuXli11zbaISCBT2ypIjBjheW7y3bst7N1r8NBDeSxZkq3gFhExAbW8g8SZc5b/\n+qsFmw3y8gwuusjJv/+dQ/v2Cm0REbNQyzuIJCcXcOONrnPZeXkGd9xxkpUrTyi4RURMRuFdBXh7\n/fbs2SGMHx9OTIyT+fOzmTYtj+rVK7mwIiJy3tRtbnLeXr+9aJGNcePCqVvXweLF2ZpsRUTExNTy\nNjlvrt/+4gsrf/97ODVqOJk/P0fBLSJicgpvkzvX9dsAP/xg4c47q2GxwJw5ObRurfPbIiJmp/A2\nufh4z2EcH+8gNdXg5purkZsLs2fnkphor+TSiYiILyi8Ta6k67fvuOMkN94YQUaGhWnT8ujTp8Dj\n80RExHw0YM3kzrx+e9s2C/HxDoYMOcmrr4aye7eFUaPyGDQo39/FFBGRCqTwrgKSkwvcI8tzc+Gm\nm6qxebOVO+44yciRnlvmIiJiXuo2r0Lsdhg6NJxvvrHRr18+kyfnYRj+LpWIiFQ0hXcV4XTC6NFh\n/Pe/IVx1VQEvvpiLtfg6JCIiUgUovKuI6dNDefvtUFq3tvPOOzmEh/u7RCIi4is6521yTic8/3wo\n06aF0aiRg/nzc6hRw9+lEhERX1LLO0AVzldus1HifOUOBzzxRBj//GcY9es7WLgwm7p1NXuaiEhV\np5Z3APJmvvKTJ2H48HA+/DCE+Hg7Cxbk0KCBgltEJBio5R2ASpuv/MQJuO22anz4YQiXX27n44+z\nFdwiIkHEpy3vSZMm8dNPP2EYBmPHjqVt27bux959910+/vhjLBYLbdq04R//+Icvi2Iq55qvPCPD\n4JZbqrFxo5Vu3Qp49dUcLespIhJkfNbyXrduHbt27WLBggVMnDiRiRMnuh/Lysri9ddf591332Xe\nvHmkpqby448/+qooplPSfOVNmjjo398V3DfckM/bbyu4RUSCUanhnZqaWq4dr1mzhm7dugHQtGlT\njh49SlZWFgAhISGEhISQnZ1NQUEBOTk51KxZs1zvUxWVNF95WpqFHTusDB16klmzcgkJqeSCiYhI\nQCi12/zBBx+kRo0a/O1vf6NPnz5Uq1attJcAkJ6eTuvWrd33Y2JiSEtLIzIykrCwMB544AG6detG\nWFgYffv2pUmTJuWvRRVTdL5yKxdeaOfQIQtHjhiMH5/LAw9ornIRkWBWanh/+umnbNu2jSVLlnDb\nbbfRqlUrBgwYUOT8tTecztMDqrKyspg9ezZLly4lMjKS22+/na1bt9KyZcsSXx8dHYHN5t2UYbGx\nUWUqWyAaMsT18+mnMGCAlZMn4e23YdCgcMDcM7BUheNzJtUnsKk+gU31KR+vBqzFx8cTHx9Px44d\nee655xg6dCiNGzdm4sSJXHTRRR5fExcXR3p6uvv+oUOHiI2NBVxd8Q0bNiQmJgaA9u3bs2nTpnOG\nd2ZmtlcVio2NIi3tuFfPDXQpKTaGDq1GaKiTd97JoXt3O2lp/i7V+alKxwdUn0Cn+gQ21ce7fXpS\n6jnvffv28cILL9CrVy/eeust7rvvPlavXs1jjz3Go48+WuLrOnbsyLJlywDYvHkzcXFxREZGAtCg\nQQNSU1PJzc0FYNOmTSV+CQhWu3YZPPRQOJGR8P772XTvbvd3kUREJECU2vK+7bbb+Nvf/sbbb79N\n3bp13dvbtm17zq7zdu3a0bp1awYOHIhhGIwfP55FixYRFRVF9+7dueuuuxg0aBBWq5XLLruM9u3b\nV0yNqgCnEx55JJzsbIO5c6FDB8+jz0VEJDgZzjNPRnuQlZXFV199RZ8+fQCYN28ef/3rX6leydco\nedsVURW6YebPt/Hgg9Xo2rWA5cttpKebuz5nqgrH50yqT2BTfQKb6uPdPj0ptdt8zJgxRc5d5+bm\nMmrUqIormRRx6JDBE0+EU726k2eeydV63CIiUkyp4X3kyBEGDRrkvn/nnXdy7NgxnxYqmP3jH2Ec\nOWLw+ON5XHihpjwVEZHiSg3v/Pz8IhO1bNq0ifx8XWfsC0uW2PjooxCuuMLOnXfqMxYREc9KHbA2\nZswYhg4dyvHjx7Hb7cTExDBt2rTKKFtQOXYMHnssjNBQJ//6Vy4WLRkjIiIlKDW8L7nkEpYtW0Zm\nZiaGYVCrVi02btxYGWULKk89FcaBAxZGj84rcW5zERER8CK8s7Ky+Oijj8jMzARc3egffvghX3/9\ntc8LFyy+/dbKnDmhtGplZ9gwz/Oai4iIFCq1c3bEiBH8+uuvLFq0iBMnTvDFF1/w5JNPVkLRgkNO\nDjz0UDgWi5MZM3IJ9byUt4iIiFup4Z2Xl8eECRNo0KABjz32GO+88w5LliypjLIFhWefDeX33y0M\nGZLPZZepu1xEREpXard5fn4+2dnZOBwOMjMziY6OZs+ePZVRtiopJcXGjBmhbNtmoWFDB7t3W2jU\nyMFjj+X5u2giImISpYb3tddey8KFCxkwYAB9+vQhJiaGxo0bV0bZqpyUFBv33nt6SdWdO12rpF13\n3UkqecI6ERExsVLDu3BucoDExEQyMjJo1aqVzwtWFc2Y4fmE9mef2Rg7VgPVRETEO6We8z5zdrW6\ndeuSkJDgDnMpm23bPH/cJW0XERHxpNSWd6tWrZg5cyaXXXYZISEh7u2JiYk+LVhVFB/vYMsWq8ft\nIiIi3io1vLds2QLA+vXr3dsMw1B4l8GuXQYffxxCdrbnHovhw9VlLiIi3is1vOfMmVMZ5ahydu50\nBfYnn9j46SdXa9tmc5KQYCcz0+DQIYMWLRwMH36S5OQCP5dWRETMpNTwvvnmmz2e43733Xd9UiAz\nKwzsjz+28b//nQ7sLl0K+Otf8+nVq4CYGD8XUkRETK/U8B4xYoT7dn5+Pt999x0RERE+LZQZvfhi\nCE8+GQ4UDezevQuIjvZz4UREpEopNbw7dOhQ5H7Hjh255557fFYgM9qzx2DKlDBiYx08/ngevXop\nsEVExHdKDe+zZ1Pbv38/v//+u88KZEZDhoSTm2uQlwcvvxxKeDg6jy0iIj5Tanjffvvt7tuGYRAZ\nGcmwYcN8WigzmTo1lA0bXB+j02mwZYv11CxqOQpwERHxiVLDe+XKlTgcDiwW10Qi+fn5Ra73DmZ2\nO7zwgudZ02bODFV4i4iIT5Q6tdeyZcsYOnSo+/4tt9zC0qVLfVoos3j33RDy8jxfu61Z00RExFdK\nTZg333yTZ555xn3/jTfe4M033/RpoczgyBGYPDkUi8Xp8XHNmiYiIr5Sang7nU6ioqLc9yMjIzW3\nOTB9ehgZGRauvdZz17hmTRMREV8p9Zx3mzZtGDFiBB06dMDpdLJ69WratGlTGWULWNu2WXj99RAu\nusjBrFm59OpVwMyZrjW64+M1a5qIiPhWqeH9+OOP8/HHH/O///0PwzD461//Sq9evSqjbAHJ6YRx\n48IoKDCYMCGHsDDXZWEKaxERqSylhndOTg4hISGMGzcOgHnz5pGTk0P16tV9XrhAtHy5lS++sJGU\nVEDPnnZ/F0dERIJQqee8H3vsMdLT0933c3NzGTVqlE8LFahOnoRx48KxWp3885956NS/iIj4Q6nh\nfeTIEQYNGuS+f+edd3Ls2DGfFipQvfJKCL//bmHw4HxatNBochER8Y9Swzs/P5/U1FT3/Z9//pn8\n/HyfFioQHTxo8NxzYcTEOHj00Tx/F0dERIJYqee8x4wZw9ChQzl+/DgOh4Po6GimTZtWGWULKJMn\nh5KVZTBtWh61avm7NCIiEsxKDe9LLrmEZcuWsX//ftauXUtKSgr3338/X3/9dWWULyD8+KOFefNC\nSEiwc9ttwdfrICIigaXU8P7xxx9ZtGgRixcvxuFw8PTTT9OjR4/KKFtAcDph7NhwnE6DiRPzsFr9\nXSIREQl2JZ7zfvXVV+nTpw8PPfQQMTExfPjhhzRq1Ii+ffsG1cIkixbZWL/eSv/++XTsqEvDRETE\n/0psec+YMYNmzZrxxBNPcOWVVwIE3bSoTidMnBhGWJiT8eM1SE1ERAJDieG9atUqUlJSGD9+PA6H\ng+Tk5KAbZX7okMHevRZ6986nUSPPC5CIiIhUthK7zWNjYxkyZAjLli1j0qRJ7N69m3379nHffffx\n5ZdfVmYZ/SY11fXxNG+ua7pFRCRweLXo9BVXXMGUKVNYvXo111xzDf/+9799Xa6AUBjeTZsqvEVE\nJHB4Fd6FIiMjGThwIAsXLvRVeQLKjh0KbxERCTxlCu9g89tvheGt890iIhI4FN7nsGOHhehoJ7Vr\nK7xFRCRwKLxLkJ8Pu3YZXHyxusxFRCSwKLxLsHu3QUGBQbNmCm8REQksCu8SaKS5iIgEKoV3CTTS\nXEREApXCuwSFLW91m4uISKBReJcgNdWCYTi56CKFt4iIBBaFdwlSUy00bOikWjV/l0RERKQohbcH\nx4/DwYMWIiOdJCVFcMEFkSQlRZCSUury5yIiIj6nNPKgcGa1X36xurdt2WLl3nurATkkJxf4qWQi\nIiJqeXtUONLck5kzQyuxJCIiIsUpvD0oHGnuybZt+shERMS/lEQenCu84+M1+lxERPxL4e1BaqqF\nkBDPi5EMH36ykksjIiJSlML7LE6nK7ybNXMwe3YOCQl2bDYnCQl2Zs/WYDUREfE/jTY/y8GDBidO\nuBYkSU4uUFiLiEjAUcv7LJrTXEREAp1PW96TJk3ip59+wjAMxo4dS9u2bQE4ePAgjzzyiPt5e/bs\nYeTIkfTv39+XxfGKwltERAKdz8J73bp17Nq1iwULFpCamsrYsWNZsGABAHXr1mXOnDkAFBQUcNtt\nt9GlSxdfFaVMtBSoiIgEOp91m69Zs4Zu3boB0LRpU44ePUpWVlax56WkpNCzZ0+qV6/uq6KUicJb\nREQCnc9a3unp6bRu3dp9PyYmhrS0NCIjI4s87/333+eNN94odX/R0RHYbNZSnwcQGxtVtsKeYedO\nqFMH4uPLv4+Kdj71CUSqT2BTfQKb6hPYKqs+lTba3Oksft30Dz/8wMUXX1ws0D3JzMz26n1iY6NI\nSzte5vIBnDwJv/8eyeWX20lLyynXPira+dQnEKk+gU31CWyqT2DzRX1K+jLgs27zuLg40tPT3fcP\nHTpEbGxskeesWrWKxMREXxWhzHbtsmC3GzRt6nmCFhERkUDgs/Du2LEjy5YtA2Dz5s3ExcUVa2H/\n/PPPtGzZ0ldFKDONNBcRETPwWbd5u3btaN26NQMHDsQwDMaPH8+iRYuIioqie/fuAKSlpVG7dm1f\nFaHMUlMNQOEtIiKBzafnvM+8lhso1sr+5JNPfPn2ZVY40rxZM4W3iIgELs2wdobUVAsWi5OLLlJ4\ni4hI4FJ4n2HHDgsNGzoJC/N3SUREREqm8D7l6FFIT7eoy1xERAKewvsUzawmIiJmofA+ReEtIiJm\nofA+ReEtIiJmofA+RZeJiYiIWSi8T9mxw0JEhJN69TQ1qoiIBDaFN+BwwO+/W7j4YgcWfSIiIhLg\nFFXA/v0G2dmGzneLiIgpKLzRYDURETEXhTdaTUxERMxF4Q389ptGmouIiHkovFHLW0REzEXhjSu8\nY2Md1Kjh75KIiIiULujDOy8P9uzRSHMRETGPoA/v33+34HQaOt8tIiKmEfThXXiZ2MUXK7xFRMQc\nFN6a01xERExG4e2eoEVzmouIiDkEfXjv2GHBanXSuLFa3iIiYg5BH96//WbQuLGT0FB/l0RERMQ7\nQR3emZmQkWHRZWIiImIqQR3eWpBERETMKKjDW9OiioiIGQV1eGtBEhERMaOgDm+1vEVExIyCOrxT\nUy1Ur+6kbl1d4y0iIuYRtOHtcLjmNW/a1IFh+Ls0IiIi3gva8N63zyA3VwuSiIiI+QRteBee79aC\nJCIiYjZBG94aaS4iImYVtOGtkeYiImJWQRveml1NRETMKqjDu25dB5GR/i6JiIhI2QRleOfkwN69\nGmkuIiLmFJTh/fvvFpxOQyPNRUTElIIyvDXSXEREzCwow7tlSztXXVVAz54F/i6KiIhImdn8XQB/\naNbMyX/+k+PvYoiIiJRLULa8RUREzEzhLSIiYjIKbxEREZNReIuIiJiMwltERMRkFN4iIiImo/AW\nERExGYW3iIiIySi8RURETEbhLSIiYjIKbxEREZNReIuIiJiMwltERMRkFN4iIiImo/AWERExGYW3\niIiIydh8ufNJkybx008/YRgGY8eOpW3btu7H9u/fz8MPP0x+fj4JCQlMmDDBl0URERGpMnzW8l63\nbh27du1iwYIFTJw4kYkTJxZ5fMqUKQwePJgPPvgAq9XKH3/84auiiIiIVCk+C+81a9bQrVs3AJo2\nbcrRo0fJysoCwOFwsGHDBrp06QLA+PHjqV+/vq+KIiIiUqX4LLzT09OJjo5234+JiSEtLQ2Aw4cP\nU716dSZPnsxNN93E9OnTfVUMERGRKsen57zP5HQ6i9w+ePAggwYNokGDBgwZMoRVq1ZxzTXXlPj6\n6OgIbDarV+8VGxt1vsUNKKpPYFN9ApvqE9hUn/LxWXjHxcWRnp7uvn/o0CFiY2MBiI6Opn79+jRq\n1AiAxMREtm/ffs7wzszM9up9Y2OjSEs7Xv6CBxjVJ7CpPoFN9Qlsqo93+/TEZ93mHTt2ZNmyZQBs\n3ryZuLg4IiMjAbDZbDRs2JCdO3e6H2/SpImviiIiIlKl+Kzl3a5dO1q3bs3AgQMxDIPx48ezaNEi\noqKi6N69O2PHjmX06NE4nU7i4+Pdg9dERETk3Hx6zvuRRx4pcr9ly5bu240bN2bevHm+fHsREZEq\nSTOsiYiImIzCW0RExGQU3iIiIiaj8BYRETEZhbeIiIjJKLxFRERMRuEtIiJiMgpvERERk1F4i4iI\nmIzCW0RExGQU3iIiIiaj8BYRETEZhbeIiIjJKLxFRERMRuEtIiJiMgpvERERkwm68E5JsZGUFMEF\nF0SSlBRBSorN30USEREpk6BKrpQUG/feW819f8sW66n7OSQnF/ivYCIiImUQVC3vGTNCPW6fOdPz\ndhERkUAUVOG9bZvn6pa0XUREJBAFVWrFxzvKtF1ERCQQBVV4jxhx0uP24cM9bxcREQlEQRXeyckF\nzJ6dQ0KCHZvNSUKCndmzNVhNRETMJahGm4MrwBXWIiJiZkHV8hYREakKFN4iIiImo/AWERExGYW3\niIiIySi8RURETEbhLSIiYjIKbxEREZNReIuIiJiMwltERMRkDKfT6fR3IURERMR7anmLiIiYjMJb\nRETEZBTeIiIiJqPwFhERMRmFt4iIiMkovEVEREzG5u8CVKRJkybx008/YRgGY8eOpW3btv4uUrmt\nXbuW4cOH07x5cwDi4+MZN26cn0tVdtu2bWPo0KHccccd3Hrrrezfv59Ro0Zht9uJjY3lmWeeITQ0\n1N/F9NrZ9Rk9ejSbN2+mVq1aANx1111cc801/i1kGUybNo0NGzZQUFDAvffey5/+9CdTH5+z67Ny\n5UrTHp+cnBxGjx5NRkYGeXl5DB06lJYtW5r2+Hiqz7Jly0x7fArl5ubSr18/hg4dSmJiYqUdnyoT\n3uvWrWPXrl0sWLCA1NRUxo4dy4IFC/xdrPPSoUMHZs2a5e9ilFt2djZPP/00iYmJ7m2zZs3i5ptv\npnfv3jz33HN88MEH3HzzzX4spfc81Qfg4YcfpnPnzn4qVfl99913bN++nQULFpCZmUlycjKJiYmm\nPT6e6nPllVea9vh88cUXtGnThnvuuYd9+/YxePBg2rVrZ9rj46k+l112mWmPT6GXXnqJmjVrApX7\n/1uV6TZfs2YN3bp1A6Bp06YcPXqUrKwsP5cquIWGhvLqq68SFxfn3rZ27Vq6du0KQOfOnVmzZo2/\nildmnupjZldccQUzZ84EoEaNGuTk5Jj6+Hiqj91u93Opyq9Pnz7cc889AOzfv5+6deua+vh4qo/Z\npaamsmPHDndvQWUenyoT3unp6URHR7vvx8TEkJaW5scSnb8dO3Zw3333cdNNN/HNN9/4uzhlZrPZ\nCA8PL7ItJyfH3Y1Uu3ZtUx0jT/UBmDt3LoMGDeKhhx7i8OHDfihZ+VitViIiIgD44IMP+Mtf/mLq\n4+OpPlar1bTHp9DAgQN55JFHGDt2rKmPT6Ez6wPm/fcDMHXqVEaPHu2+X5nHp8p0m5/N7LO+XnTR\nRQwbNozevXuzZ88eBg0axGeffWaa81veMPsxArj22mupVasWrVq14pVXXuGFF17giSee8HexymTF\nihV88MEHvPHGG/To0cO93azH58z6bNq0yfTHZ/78+WzZsoVHH320yDEx6/E5sz5jx4417fH5z3/+\nw6WXXkrDhg09Pu7r41NlWt5xcXGkp6e77x86dIjY2Fg/luj81K1blz59+mAYBo0aNaJOnTocPHjQ\n38U6bxEREeTm5gJw8OBB03dBJyYm0qpVKwC6dOnCtm3b/Fyislm9ejUvv/wyr776KlFRUaY/PmfX\nx8zHZ9OmTezfvx+AVq1aYbfbqV69ummPj6f6xMfHm/b4rFq1is8//5wbbriB999/nxdffLFS//1U\nmfDu2LEjy5YtA2Dz5s3ExcURGRnp51KV38cff8zrr78OQFpaGhkZGVXiHNFVV13lPk6fffYZV199\ntZ9LdH7+/ve/s2fPHsB1vqvw6gAzOH78ONOmTWP27Nnu0b5mPj6e6mPm47N+/XreeOMNwHVaMDs7\n29THx1N9nnjiCdMenxkzZvDhhx+ycOFCBgwYwNChQyv1+FSpVcWeffZZ1q9fj2EYjB8/npYtW/q7\nSOWWlZXFI488wrFjx8jPz2fYsGEkJSX5u1hlsmnTJqZOncq+ffuw2WzUrVuXZ599ltGjR5OXl0f9\n+vWZPHkyISEh/i6qVzzV59Zbb+WVV16hWrVqREREMHnyZGrXru3vonplwYIFPP/88zRp0sS9bcqU\nKTz++OOmPD6e6nPdddcxd+5cUx6f3Nxc/vGPf7B//35yc3MZNmwYbdq04bHHHjPl8fFUn4iICJ55\n5hlTHp8zPf/88zRo0IBOnTpV2vGpUuEtIiISDKpMt7mIiEiwUHiLiIiYjMJbRETEZBTeIiIiJqPw\nFhERMZkqO8OaiMDevXvp1asXl112WZHtSUlJ3H333ee9/7Vr1zJjxgzmzZt33vsSEe8pvEWquJiY\nGObMmePvYohIBVJ4iwSphIQEhg4dytq1azlx4gRTpkwhPj6en376iSlTpmCz2TAMgyeeeIJmzZqx\nc+dOxo0bh8PhICwsjMmTJwPgcDgYP348W7ZsITQ0lNmzZwMwcuRIjh07RkFBAZ07d+b+++/3Z3VF\nqhSd8xYJUna7nebNmzNnzhxuuukm99rxo0aNYsyYMcyZM4c777yTp556CoDx48dz11138e6773L9\n9dezZMkSwLUs4t///ncWLlyIzWbj66+/5ttvv6WgoID33nuP+fPnExERgcPh8FtdRaoatbxFqrjD\nhw9z2223Fdn26KOPAtCpUycA2rVrx+uvv86xY8fIyMigbdu2AHTo0IGHH34YgP/973906NABgL59\n+wKuc94XX3wxderUAaBevXocO3aMLl26MGvWLIYPH05SUhIDBgzAYlFbQaSiKLxFqrhznfM+c3Zk\nwzAwDKPExwGPrWer1VpsW+3atfnoo4/44Ycf+Pzzz7n++utJSUnxuB66iJSdvgqLBLHvvvsOgA0b\nNtCiRQuioqKIjY3lp59+AmDNmjVceumlgKt1vnr1agAWL17Mc889V+J+v/76a1atWsXll1/OqFGj\niIiIICMjw8e1EQkeanmLVHGeus0vvPBCAH755RfmzZvH0aNHmTp1KgBTp05lypQpWK1WLBYLTz75\nJADjxo1j3LhxvPfee9hsNiZNmsTu3bs9vmeTJk0YPXo0r732GlarlU6dOtGgQQPfVVIkyGhVMZEg\n1aJFCzZv3ozNpu/wImajbnMRERGTUctbRETEZNTyFhERMRmFt4iIiMkovEVERExG4S0iImIyCm8R\nERGTUXiLiIiYzP8DccoY9iLpWQ8AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 576x396 with 1 Axes>"
+      "cell_type": "code",
+      "metadata": {
+        "id": "jfHmj_Bisaka",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        },
+        "outputId": "be5ebbc9-e72a-4d0c-9631-475393c0f62a"
+      },
+      "source": [
+        "\"\"\" imdb.load_data で \"ValueError: Object arrays cannot be loaded when allow_pickle=False\" \n",
+        "が起きるのを防ぐためにnumpyをダウングレード\n",
+        "(参照：https://stackoverflow.com/questions/55824625/how-to-fix-object-arrays-cannot-be-loaded-when-allow-pickle-false-in-the-sketc)\n",
+        "\"\"\"\n",
+        "!pip install numpy==1.16.2"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Requirement already satisfied: numpy==1.16.2 in /usr/local/lib/python3.6/dist-packages (1.16.2)\n"
+          ],
+          "name": "stdout"
+        }
       ]
-     },
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "5iguN9LGxrOk",
+        "outputId": "fd7ecc95-074b-418e-83b4-3162a863385a",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        }
+      },
+      "source": [
+        "import tensorflow as tf\n",
+        "from tensorflow import keras\n",
+        "\n",
+        "import numpy as np\n",
+        "\n",
+        "print(tf.__version__)"
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "1.13.1\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "jAqGNZ44p6Cc",
+        "colab_type": "text"
+      },
+      "source": [
+        "\n",
+        "## B. データセットを準備する\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "lXI8AdMuxrOm"
+      },
+      "source": [
+        "### 1. IMDBデータセットをダウンロードする\n",
+        "\n",
+        " IMDBデータセットはTensorFlowに同梱されています。レビュー（単語の並び）が整数の並びに変換されるよう、すでに前処理されています。各整数は辞書内の特定の単語を表します。 \n",
+        "\n",
+        "次のコードで、IMDBデータセットをダウンロードします（すでにダウンロード済みの場合はキャッシュコピーを使用します）。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "_vY-ROKbxrOn",
+        "colab": {}
+      },
+      "source": [
+        "imdb = keras.datasets.imdb\n",
+        "\n",
+        "(train_data, train_labels), (test_data, test_labels) = imdb.load_data(num_words=10000)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "It6WhG12xrOq"
+      },
+      "source": [
+        "\n",
+        "引数`num_words=10000`で、学習データセット中、最も頻繁に出現する上位1万語のみ保持するよう指定します。データのサイズが大きくなり過ぎないよう、あまり出てこない単語は破棄されます。 \n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "AvRq7MeQxrOr"
+      },
+      "source": [
+        "\n",
+        "### 2. データセットの中身を見てみる\n",
+        "\n",
+        "少し時間をかけて、データのフォーマットを理解しましょう。データセットは前処理されています。各例は、映画レビューの単語を表す整数の並び（配列）です。各ラベルは0または1の整数値です。0は否定的なレビュー、1は肯定的なレビューを表します。 \n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "VaTgE3KyKMmk"
+      },
+      "source": [
+        ""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "7Qu3dfyDxrOt",
+        "outputId": "b6e9c78b-6214-44fc-9a11-c84df5c6fdc6",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        }
+      },
+      "source": [
+        "print(\"Training entries: {}, labels: {}\".format(len(train_data), len(train_labels)))"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Training entries: 25000, labels: 25000\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "d504bc4UxrOx"
+      },
+      "source": [
+        "\n",
+        "レビューのテキストは整数に変換され、各整数は辞書内にある単語を表します。最初のレビューは次のようになります。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "XcykwkYBxrOy",
+        "outputId": "ea0c2696-cdbe-4b8a-909d-917dd2f1e760",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 55
+        }
+      },
+      "source": [
+        "print(train_data[0])"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[1, 14, 22, 16, 43, 530, 973, 1622, 1385, 65, 458, 4468, 66, 3941, 4, 173, 36, 256, 5, 25, 100, 43, 838, 112, 50, 670, 2, 9, 35, 480, 284, 5, 150, 4, 172, 112, 167, 2, 336, 385, 39, 4, 172, 4536, 1111, 17, 546, 38, 13, 447, 4, 192, 50, 16, 6, 147, 2025, 19, 14, 22, 4, 1920, 4613, 469, 4, 22, 71, 87, 12, 16, 43, 530, 38, 76, 15, 13, 1247, 4, 22, 17, 515, 17, 12, 16, 626, 18, 2, 5, 62, 386, 12, 8, 316, 8, 106, 5, 4, 2223, 5244, 16, 480, 66, 3785, 33, 4, 130, 12, 16, 38, 619, 5, 25, 124, 51, 36, 135, 48, 25, 1415, 33, 6, 22, 12, 215, 28, 77, 52, 5, 14, 407, 16, 82, 2, 8, 4, 107, 117, 5952, 15, 256, 4, 2, 7, 3766, 5, 723, 36, 71, 43, 530, 476, 26, 400, 317, 46, 7, 4, 2, 1029, 13, 104, 88, 4, 381, 15, 297, 98, 32, 2071, 56, 26, 141, 6, 194, 7486, 18, 4, 226, 22, 21, 134, 476, 26, 480, 5, 144, 30, 5535, 18, 51, 36, 28, 224, 92, 25, 104, 4, 226, 65, 16, 38, 1334, 88, 12, 16, 283, 5, 16, 4472, 113, 103, 32, 15, 16, 5345, 19, 178, 32]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "a4Mls2KHxrO3"
+      },
+      "source": [
+        "\n",
+        "映画のレビュー文は、それぞれ長さが異なります。以下のコードで、最初のレビューと2番目のレビューの単語数を確認してみましょう。一般に、ニューラルネットワークへの入力は同じ長さである必要があります。後でこの問題を解決しましょう。\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "5azJ69ToxrO4",
+        "outputId": "09daa0e8-6e38-4fa9-8a3b-0b39b6918817",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        }
+      },
+      "source": [
+        "len(train_data[0]), len(train_data[1])"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(218, 189)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 8
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "Ra11Xz_nxrO5"
+      },
+      "source": [
+        "\n",
+        "### 3. 整数を単語に戻す\n",
+        "\n",
+        "整数をテキストに変換して戻す方法を知っておくと便利です。ここでは、整数から文字列への対応づけを持つ辞書オブジェクトへ、問い合わせをするためのヘルパー関数を作ります。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "ByGieyTrxrO6",
+        "colab": {}
+      },
+      "source": [
+        "# A dictionary mapping words to an integer index\n",
+        "word_index = imdb.get_word_index()\n",
+        "\n",
+        "# The first indices are reserved\n",
+        "word_index = {k:(v+3) for k,v in word_index.items()} \n",
+        "word_index[\"<PAD>\"] = 0\n",
+        "word_index[\"<START>\"] = 1\n",
+        "word_index[\"<UNK>\"] = 2  # unknown\n",
+        "word_index[\"<UNUSED>\"] = 3\n",
+        "\n",
+        "reverse_word_index = dict([(value, key) for (key, value) in word_index.items()])\n",
+        "\n",
+        "def decode_review(text):\n",
+        "    return ' '.join([reverse_word_index.get(i, '?') for i in text])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "9y8HH1AoxrO8"
+      },
+      "source": [
+        "\n",
+        "これで`decode_review`関数を使って最初のレビューのテキストを表示することができます。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "f-KYJS3axrO9",
+        "outputId": "2ed4cc0c-9297-4996-8c22-b4388757e531",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 55
+        }
+      },
+      "source": [
+        "decode_review(train_data[0])"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "\"<START> this film was just brilliant casting location scenery story direction everyone's really suited the part they played and you could just imagine being there robert <UNK> is an amazing actor and now the same being director <UNK> father came from the same scottish island as myself so i loved the fact there was a real connection with this film the witty remarks throughout the film were great it was just brilliant so much that i bought the film as soon as it was released for <UNK> and would recommend it to everyone to watch and the fly fishing was amazing really cried at the end it was so sad and you know what they say if you cry at a film it must have been good and this definitely was also <UNK> to the two little boy's that played the <UNK> of norman and paul they were just brilliant children are often left out of the <UNK> list i think because the stars that play them all grown up are such a big profile for the whole film but these children are amazing and should be praised for what they have done don't you think the whole story was so lovely because it was true and was someone's life after all that was shared with us all\""
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 10
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "GVyXzVW7xrO_"
+      },
+      "source": [
+        "\n",
+        "## C. データセットを前処理する\n",
+        "\n",
+        "レビュー（整数の配列）は、ニューラルネットワークへ入力する前にテンソルに変換します。変換には、いくつか方法があります。 \n",
+        "\n",
+        "- ワンホットエンコーディングと同様、配列を単語の出現を示す0と1のベクトルに変換します。たとえば、シーケンス `[3、5]` は、1であるインデックス3と5を除いて、すべて0の1万次元ベクトルになります。次に、これをネットワークの最初の層、つまり、浮動小数点のベクトルデータを処理できる全結合層にします。ただし、この方法では大量のメモリが必要です。 `num_words * num_reviews`の形をもつ行列を保持するからです。 \n",
+        "- 代わりに、すべて同じ長さになるように配列をパディングしてから、`max_length * num_reviews`の形をもつ整数テンソルを作成することもできます。この形状を処理できるembedding層をネットワークの最初の層として使います。\n",
+        "\n",
+        "このチュートリアルでは、後者を使います。 \n",
+        "\n",
+        "入力の映画レビューを同じ長さである必要があるので、 [pad_sequences](https://www.tensorflow.org/api_docs/python/tf/keras/preprocessing/sequence/pad_sequences)関数を使い、長さを標準化します。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "vLU5uhCyxrPA",
+        "colab": {}
+      },
+      "source": [
+        "train_data = keras.preprocessing.sequence.pad_sequences(train_data,\n",
+        "                                                        value=word_index[\"<PAD>\"],\n",
+        "                                                        padding='post',\n",
+        "                                                        maxlen=256)\n",
+        "\n",
+        "test_data = keras.preprocessing.sequence.pad_sequences(test_data,\n",
+        "                                                       value=word_index[\"<PAD>\"],\n",
+        "                                                       padding='post',\n",
+        "                                                       maxlen=256)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "nejMKis6xrPD"
+      },
+      "source": [
+        "\n",
+        "例の長さを見てみましょう。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "BB-683yQxrPE",
+        "outputId": "0d765b4f-0ce6-4849-db68-5cc213f06bcb",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        }
+      },
+      "source": [
+        "len(train_data[0]), len(train_data[1])"
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(256, 256)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 12
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "WGTQ2XeJxrPJ"
+      },
+      "source": [
+        "\n",
+        "そして、（今はパディングされた）最初のレビューを調べます。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "mzyoemxxxrPJ",
+        "outputId": "fcf0c94f-eaa1-484d-c933-5c3100efa081",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 351
+        }
+      },
+      "source": [
+        "print(train_data[0])"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "[   1   14   22   16   43  530  973 1622 1385   65  458 4468   66 3941\n",
+            "    4  173   36  256    5   25  100   43  838  112   50  670    2    9\n",
+            "   35  480  284    5  150    4  172  112  167    2  336  385   39    4\n",
+            "  172 4536 1111   17  546   38   13  447    4  192   50   16    6  147\n",
+            " 2025   19   14   22    4 1920 4613  469    4   22   71   87   12   16\n",
+            "   43  530   38   76   15   13 1247    4   22   17  515   17   12   16\n",
+            "  626   18    2    5   62  386   12    8  316    8  106    5    4 2223\n",
+            " 5244   16  480   66 3785   33    4  130   12   16   38  619    5   25\n",
+            "  124   51   36  135   48   25 1415   33    6   22   12  215   28   77\n",
+            "   52    5   14  407   16   82    2    8    4  107  117 5952   15  256\n",
+            "    4    2    7 3766    5  723   36   71   43  530  476   26  400  317\n",
+            "   46    7    4    2 1029   13  104   88    4  381   15  297   98   32\n",
+            " 2071   56   26  141    6  194 7486   18    4  226   22   21  134  476\n",
+            "   26  480    5  144   30 5535   18   51   36   28  224   92   25  104\n",
+            "    4  226   65   16   38 1334   88   12   16  283    5   16 4472  113\n",
+            "  103   32   15   16 5345   19  178   32    0    0    0    0    0    0\n",
+            "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
+            "    0    0    0    0    0    0    0    0    0    0    0    0    0    0\n",
+            "    0    0    0    0]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "TpUMYWyHxrPO"
+      },
+      "source": [
+        "\n",
+        "## D. モデルを作成する\n",
+        "\n",
+        "ニューラルネットワークは、レイヤを連ねる、または重ねて作ります。構造（アーキテクチャ）を決める、2つ重要なポイントがあります。\n",
+        "\n",
+        "- モデルにいくつのレイヤを使うか？\n",
+        "- 各層にいくつの*ノード*を使うか？ \n",
+        "\n",
+        "この例では、入力は単語インデックスの配列です。出力される予測ラベルは0か1のいずれかです。この課題を解くモデルを作りましょう。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "7qtgBGp_xrPO",
+        "outputId": "14ab2724-145e-4b85-ff4e-87a3c549d636",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 354
+        }
+      },
+      "source": [
+        "# input shape is the vocabulary count used for the movie reviews (10,000 words)\n",
+        "vocab_size = 10000\n",
+        "\n",
+        "model = keras.Sequential()\n",
+        "model.add(keras.layers.Embedding(vocab_size, 16))\n",
+        "model.add(keras.layers.GlobalAveragePooling1D())\n",
+        "model.add(keras.layers.Dense(16, activation=tf.nn.relu))\n",
+        "model.add(keras.layers.Dense(1, activation=tf.nn.sigmoid))\n",
+        "\n",
+        "model.summary()"
+      ],
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "WARNING:tensorflow:From /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Colocations handled automatically by placer.\n",
+            "_________________________________________________________________\n",
+            "Layer (type)                 Output Shape              Param #   \n",
+            "=================================================================\n",
+            "embedding (Embedding)        (None, None, 16)          160000    \n",
+            "_________________________________________________________________\n",
+            "global_average_pooling1d (Gl (None, 16)                0         \n",
+            "_________________________________________________________________\n",
+            "dense (Dense)                (None, 16)                272       \n",
+            "_________________________________________________________________\n",
+            "dense_1 (Dense)              (None, 1)                 17        \n",
+            "=================================================================\n",
+            "Total params: 160,289\n",
+            "Trainable params: 160,289\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "pEJ5VVuRxrPU"
+      },
+      "source": [
+        "\n",
+        "これらの層を順番に積み重ねて分類器を作ります。\n",
+        "\n",
+        "1. 最初の層は`Embedding`層です。この層は整数で表された単語を取り、各単語のインデックスに対応した単語の埋め込みベクトル（または、単語の分散表現）を返します。これらの埋め込みベクトルも、モデルの学習が進むのと同時に、学習が進みます。ベクトルは出力配列に次元を追加します。結果得られる次元は`(batch, sequence, embedding)`です。 \n",
+        "1. 次に、 `GlobalAveragePooling1D`レイヤは、シーケンスにある単語毎の埋め込みベクトルの各次元を、単語横断で平均をとることで、各レビューに対応する固定長出力ベクトルを返します。これで、モデルは可変長の入力を固定長として扱えるようになります。平均を取るのは、考えうる限り一番簡単な方法でしょう。 \n",
+        "1. この固定長出力ベクトルは、16個のノードを持つ全結合層（ `Dense` ）を通り、処理されます。 \n",
+        "1. 最終層の単一の出力ノードとは、全結合で接続されます。 `sigmoid`を活性化関数として使い、出力ノードの値は0から1の間の浮動小数点数(float型)として、確率、または確信度を表します。 \n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "FIYsvn-RxrPV"
+      },
+      "source": [
+        "\n",
+        "### 1. ノード（隠れユニット）\n",
+        "\n",
+        "\n",
+        "上記のモデルには、入力と出力の間に2つの中間層（または、隠れ層）があります。出力数（ユニット、ノード、またはニューロンと呼びます）は、レイヤが表現できる空間の次元です。言い換えると、内部表現を学習するときにネットワークが許容する自由度です。 \n",
+        "\n",
+        "モデルがより多くのノード（高次元の表現空間）やレイヤを持つと、ネットワークはより複雑な表現を学ぶことができます。しかし、同時にネットワークの計算コストが高くなり、不要なパターン（つまり学習データでの精度は向上するが、テストデータでの精度は向上しないパターン）の学習をしてしまうことがあります。これは*過学習*と呼ばれており、後で触れます。 \n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "cGiwZcACxrPW"
+      },
+      "source": [
+        "\n",
+        "### 2. 損失関数とオプティマイザ\n",
+        "\n",
+        "モデルには、損失関数と学習用のオプティマイザが必要です。今回の課題は、二項分類問題です。モデルは確率（活性化関数としてのSigmoid関数を含む単一層）を出力するので、 `binary_crossentropy` という損失関数を使います。 \n",
+        "\n",
+        "損失関数は他にも選ぶことができます。例えば、 `mean_squared_error`が選べます。ただ一般に、 `binary_crossentropy`は、確率を扱うのに適しています。確率分布間、またはこの場合は正解データの分布と予測データの分布間の「距離」を測定します。 \n",
+        "\n",
+        "後に回帰問題をみてゆくとき（たとえば家の価格を予測するとき）、平均二乗誤差と呼ばれる別の損失関数を使います。\n",
+        "\n",
+        "次に、指定したオプティマイザと損失関数を使うよう、下の関数でモデルをコンパイルします。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "Efbx8v3wxrPX",
+        "colab": {}
+      },
+      "source": [
+        "model.compile(optimizer=tf.train.AdamOptimizer(),\n",
+        "              loss='binary_crossentropy',\n",
+        "              metrics=['accuracy'])"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EIjNsfCKp6Db",
+        "colab_type": "text"
+      },
+      "source": [
+        "## E. モデルを学習させる"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "12DJ2q7qxrPZ"
+      },
+      "source": [
+        "\n",
+        "### 1. 検証データセットを準備する\n",
+        "\n",
+        "学習中、モデルの精度を未知のデータで確認します（検証、Validation）。そのため、元の学習データから10,000個の例を分けて、*検証データセット*を準備します。\n",
+        "\n",
+        "なぜ今テストデータセットを使わないのでしょうか？なぜなら、学習データのみを使用してモデルを学習・調整し、その間に検証データセットを使います。そして、次にテストデータを1回だけ使用して精度を評価したいからです。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "Qy23KniexrPa",
+        "colab": {}
+      },
+      "source": [
+        "x_val = train_data[:10000]\n",
+        "partial_x_train = train_data[10000:]\n",
+        "\n",
+        "y_val = train_labels[:10000]\n",
+        "partial_y_train = train_labels[10000:]"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "4cwmnVW_xrPc"
+      },
+      "source": [
+        "\n",
+        "### 2. モデルを学習させる\n",
+        "\n",
+        " 512サンプルのミニバッチで40エポック、モデルを学習させます。これは、`x_train`と`y_train`テンソルの全サンプルを、40回繰り返し使って学習します。学習中に、検証セットからの1万サンプルでモデルの誤差(loss)と精度を監視します。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "YFQp5YG4xrPc",
+        "outputId": "6641ac02-29a3-4f62-e0e7-d175b909885e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1515
+        }
+      },
+      "source": [
+        "history = model.fit(partial_x_train,\n",
+        "                    partial_y_train,\n",
+        "                    epochs=40,\n",
+        "                    batch_size=512,\n",
+        "                    validation_data=(x_val, y_val),\n",
+        "                    verbose=1)"
+      ],
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Train on 15000 samples, validate on 10000 samples\n",
+            "WARNING:tensorflow:From /usr/local/lib/python3.6/dist-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+            "Instructions for updating:\n",
+            "Use tf.cast instead.\n",
+            "Epoch 1/40\n",
+            "15000/15000 [==============================] - 1s 51us/sample - loss: 0.6911 - acc: 0.6663 - val_loss: 0.6886 - val_acc: 0.7237\n",
+            "Epoch 2/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.6842 - acc: 0.7221 - val_loss: 0.6793 - val_acc: 0.7336\n",
+            "Epoch 3/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.6699 - acc: 0.7570 - val_loss: 0.6616 - val_acc: 0.7458\n",
+            "Epoch 4/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.6458 - acc: 0.7691 - val_loss: 0.6346 - val_acc: 0.7472\n",
+            "Epoch 5/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.6116 - acc: 0.7958 - val_loss: 0.5992 - val_acc: 0.7839\n",
+            "Epoch 6/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.5689 - acc: 0.8157 - val_loss: 0.5584 - val_acc: 0.8108\n",
+            "Epoch 7/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.5217 - acc: 0.8355 - val_loss: 0.5144 - val_acc: 0.8221\n",
+            "Epoch 8/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.4746 - acc: 0.8509 - val_loss: 0.4739 - val_acc: 0.8369\n",
+            "Epoch 9/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.4309 - acc: 0.8665 - val_loss: 0.4375 - val_acc: 0.8459\n",
+            "Epoch 10/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.3924 - acc: 0.8769 - val_loss: 0.4075 - val_acc: 0.8536\n",
+            "Epoch 11/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.3597 - acc: 0.8852 - val_loss: 0.3827 - val_acc: 0.8611\n",
+            "Epoch 12/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.3322 - acc: 0.8918 - val_loss: 0.3634 - val_acc: 0.8645\n",
+            "Epoch 13/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.3097 - acc: 0.8972 - val_loss: 0.3466 - val_acc: 0.8701\n",
+            "Epoch 14/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.2894 - acc: 0.9032 - val_loss: 0.3343 - val_acc: 0.8739\n",
+            "Epoch 15/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.2725 - acc: 0.9067 - val_loss: 0.3243 - val_acc: 0.8746\n",
+            "Epoch 16/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.2573 - acc: 0.9122 - val_loss: 0.3158 - val_acc: 0.8765\n",
+            "Epoch 17/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.2433 - acc: 0.9162 - val_loss: 0.3087 - val_acc: 0.8781\n",
+            "Epoch 18/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.2309 - acc: 0.9212 - val_loss: 0.3028 - val_acc: 0.8811\n",
+            "Epoch 19/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.2198 - acc: 0.9239 - val_loss: 0.2977 - val_acc: 0.8829\n",
+            "Epoch 20/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.2097 - acc: 0.9279 - val_loss: 0.2943 - val_acc: 0.8822\n",
+            "Epoch 21/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1995 - acc: 0.9331 - val_loss: 0.2913 - val_acc: 0.8834\n",
+            "Epoch 22/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1910 - acc: 0.9359 - val_loss: 0.2891 - val_acc: 0.8842\n",
+            "Epoch 23/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1824 - acc: 0.9405 - val_loss: 0.2879 - val_acc: 0.8837\n",
+            "Epoch 24/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.1749 - acc: 0.9437 - val_loss: 0.2861 - val_acc: 0.8854\n",
+            "Epoch 25/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1673 - acc: 0.9468 - val_loss: 0.2850 - val_acc: 0.8856\n",
+            "Epoch 26/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1604 - acc: 0.9500 - val_loss: 0.2855 - val_acc: 0.8831\n",
+            "Epoch 27/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.1540 - acc: 0.9522 - val_loss: 0.2851 - val_acc: 0.8851\n",
+            "Epoch 28/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1479 - acc: 0.9546 - val_loss: 0.2853 - val_acc: 0.8850\n",
+            "Epoch 29/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1426 - acc: 0.9578 - val_loss: 0.2875 - val_acc: 0.8836\n",
+            "Epoch 30/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1370 - acc: 0.9593 - val_loss: 0.2867 - val_acc: 0.8863\n",
+            "Epoch 31/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.1314 - acc: 0.9613 - val_loss: 0.2879 - val_acc: 0.8867\n",
+            "Epoch 32/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1262 - acc: 0.9643 - val_loss: 0.2894 - val_acc: 0.8863\n",
+            "Epoch 33/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.1214 - acc: 0.9656 - val_loss: 0.2918 - val_acc: 0.8836\n",
+            "Epoch 34/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1170 - acc: 0.9671 - val_loss: 0.2935 - val_acc: 0.8858\n",
+            "Epoch 35/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.1129 - acc: 0.9680 - val_loss: 0.2967 - val_acc: 0.8839\n",
+            "Epoch 36/40\n",
+            "15000/15000 [==============================] - 0s 18us/sample - loss: 0.1086 - acc: 0.9705 - val_loss: 0.2983 - val_acc: 0.8846\n",
+            "Epoch 37/40\n",
+            "15000/15000 [==============================] - 0s 19us/sample - loss: 0.1044 - acc: 0.9716 - val_loss: 0.3007 - val_acc: 0.8843\n",
+            "Epoch 38/40\n",
+            "15000/15000 [==============================] - 0s 20us/sample - loss: 0.1006 - acc: 0.9728 - val_loss: 0.3042 - val_acc: 0.8832\n",
+            "Epoch 39/40\n",
+            "15000/15000 [==============================] - 0s 21us/sample - loss: 0.0975 - acc: 0.9739 - val_loss: 0.3074 - val_acc: 0.8824\n",
+            "Epoch 40/40\n",
+            "15000/15000 [==============================] - 0s 21us/sample - loss: 0.0935 - acc: 0.9762 - val_loss: 0.3096 - val_acc: 0.8819\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "KtrnLQqNxrPj"
+      },
+      "source": [
+        "\n",
+        "## F. 学習済みモデルを評価する\n",
+        "\n",
+        "学習したモデルの性能を見てみましょう。以下の2つの値が返されます。\n",
+        "\n",
+        "- 誤差（私たちのエラーを表す数値、低い値の方が優れています）\n",
+        "- 精度 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "SvGYTAIuxrPj",
+        "outputId": "87c9ac5c-01ec-42b2-a8fe-3e9dd015f3c8",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 52
+        }
+      },
+      "source": [
+        "results = model.evaluate(test_data, test_labels)\n",
+        "\n",
+        "print(results)"
+      ],
+      "execution_count": 18,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "25000/25000 [==============================] - 1s 55us/sample - loss: 0.3307 - acc: 0.8719\n",
+            "[0.3307314974832535, 0.87188]\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "GCI3laxDxrPl"
+      },
+      "source": [
+        "\n",
+        "このような、とても素朴なアプローチでも、約87％の精度を達成できました。より高度なアプローチでは、モデルは95％に近づくはずです。 \n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "mdcPGcGYxrPm"
+      },
+      "source": [
+        "\n",
+        "### 1. 精度と誤差(loss)の時系列グラフを作成する\n",
+        "\n",
+        " `model.fit()`は、学習中に起こったことすべてを含む辞書を含む`History`オブジェクトを返します。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "JOkHmBPQxrPn",
+        "outputId": "9b279612-cb19-44bb-fa65-93a5737f5704",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        }
+      },
+      "source": [
+        "history_dict = history.history\n",
+        "history_dict.keys()"
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "dict_keys(['loss', 'acc', 'val_loss', 'val_acc'])"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 19
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "g6OaI8IkxrPp"
+      },
+      "source": [
+        "\n",
+        "学習中の、以下4つの値の推移が保存されています。\n",
+        "\n",
+        "- acc 学習データセットに対する精度\n",
+        "- loss　学習データセットに対する誤差\n",
+        "- val_acc　検証データセットに対する精度\n",
+        "- val_loss　検証データセットに対する誤差\n",
+        "\n",
+        "学習および検証中に監視される各メトリックに1つです。これらを使って、比較のために学習・検証データセットの誤差、精度（正解率）をプロットできます。 \n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "luU9i7G9xrPp",
+        "outputId": "dce3732c-a45c-4ae1-d1df-22f19b33fa4d",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 295
+        }
+      },
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "acc = history.history['acc']\n",
+        "val_acc = history.history['val_acc']\n",
+        "loss = history.history['loss']\n",
+        "val_loss = history.history['val_loss']\n",
+        "\n",
+        "epochs = range(1, len(acc) + 1)\n",
+        "\n",
+        "# \"bo\" is for \"blue dot\"\n",
+        "plt.plot(epochs, loss, 'bo', label='Training loss')\n",
+        "# b is for \"solid blue line\"\n",
+        "plt.plot(epochs, val_loss, 'b', label='Validation loss')\n",
+        "plt.title('Training and validation loss')\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Loss')\n",
+        "plt.legend()\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xl8VPXZ///XBQQBWQXcCCbgxi5g\nBCm1uLaoFYoiNxjcqqK2SrW1t4jrbUvrVkUtP3/VVrQFpd56u7aWaqVauyigiCIiiKgBZFMQBJTA\n9f3jcyaZhEkyJJnMkvfz8TiPOefMmTPXHMhc81nO52PujoiICECTdAcgIiKZQ0lBRETKKCmIiEgZ\nJQURESmjpCAiImWUFEREpIySgtQrM2tqZlvM7KD6PDadzOwQM6v3vttmdqKZrYjbXmJmxyRzbC3e\n67dmNrm2r6/mvD83s4fq+7ySPs3SHYCkl5ltidtsBXwF7Iy2L3b3mXtyPnffCbSu72MbA3c/vD7O\nY2YXAuPd/di4c19YH+eW3Kek0Mi5e9mXcvRL9EJ3f7Gq482smbuXNkRsItLwVH0k1YqqB/5oZo+a\n2WZgvJkNMbP/mNlGM1ttZveYWV50fDMzczMrjLZnRM8/b2abzezfZtZtT4+Nnj/ZzN43s01mdq+Z\n/dPMzqsi7mRivNjMlpnZ52Z2T9xrm5rZXWa2wcyWA8OruT7XmtmsSvummdmd0fqFZrY4+jwfRL/i\nqzpXiZkdG623MrM/RLEtAo6sdOx1ZrY8Ou8iMxsR7e8L/Bo4JqqaWx93bW+Ke/0l0WffYGZPmdkB\nyVybmpjZqCiejWb2kpkdHvfcZDNbZWZfmNl7cZ/1aDN7I9q/xsxuT/b9JAXcXYsW3B1gBXBipX0/\nB74GTiP8iGgJHAUMJpQ0uwPvA5dFxzcDHCiMtmcA64EiIA/4IzCjFsfuC2wGRkbP/RjYAZxXxWdJ\nJsangXZAIfBZ7LMDlwGLgHygI/BK+FNJ+D7dgS3A3nHnXgsURdunRccYcDywDegXPXcisCLuXCXA\nsdH6HcDfgQ5AAfBupWPHAAdE/yZnRTHsFz13IfD3SnHOAG6K1r8dxdgfaAH8f8BLyVybBJ//58BD\n0XrPKI7jo3+jycCSaL038BGwf3RsN6B7tD4XGBettwEGp/tvoTEvKilIMl5192fdfZe7b3P3ue7+\nmruXuvty4H5gWDWvf9zd57n7DmAm4ctoT4/9LrDA3Z+OnruLkEASSjLGX7r7JndfQfgCjr3XGOAu\ndy9x9w3ALdW8z3LgHUKyAjgJ+Nzd50XPP+vuyz14CfgbkLAxuZIxwM/d/XN3/4jw6z/+fR9z99XR\nv8kjhIRelMR5AYqB37r7AnffDkwChplZftwxVV2b6owFnnH3l6J/o1sIiWUwUEpIQL2jKsgPo2sH\nIbkfamYd3X2zu7+W5OeQFFBSkGR8Er9hZj3M7E9m9qmZfQHcDHSq5vWfxq1vpfrG5aqOPTA+Dnd3\nwi/rhJKMMan3IvzCrc4jwLho/axoOxbHd83sNTP7zMw2En6lV3etYg6oLgYzO8/M3oqqaTYCPZI8\nL4TPV3Y+d/8C+BzoEnfMnvybVXXeXYR/oy7uvgT4CeHfYW1UHbl/dOj5QC9giZm9bmanJPk5JAWU\nFCQZlbtj/obw6/gQd28L3ECoHkml1YTqHADMzKj4JVZZXWJcDXSN266py+xjwIlm1oVQYngkirEl\n8DjwS0LVTnvgr0nG8WlVMZhZd+A+4FKgY3Te9+LOW1P32VWEKqnY+doQqqlWJhHXnpy3CeHfbCWA\nu89w96GEqqOmhOuCuy9x97GEKsJfAU+YWYs6xiK1pKQgtdEG2AR8aWY9gYsb4D2fAwaa2Wlm1gz4\nEdA5RTE+BlxhZl3MrCNwdXUHu/unwKvAQ8ASd18aPbUX0BxYB+w0s+8CJ+xBDJPNrL2F+zgui3uu\nNeGLfx0hP15EKCnErAHyYw3rCTwKXGBm/cxsL8KX8z/cvcqS1x7EPMLMjo3e+6eEdqDXzKynmR0X\nvd+2aNlF+ABnm1mnqGSxKfpsu+oYi9SSkoLUxk+Acwl/8L8hNAinlLuvAf4LuBPYABwMvEm4r6K+\nY7yPUPf/NqER9PEkXvMIoeG4rOrI3TcCVwJPEhprRxOSWzJuJJRYVgDPA7+PO+9C4F7g9eiYw4H4\nevgXgKXAGjOLrwaKvf4vhGqcJ6PXH0RoZ6gTd19EuOb3ERLWcGBE1L6wF3AboR3oU0LJ5NropacA\niy30brsD+C93/7qu8UjtWKiaFckuZtaUUF0x2t3/ke54RHKFSgqSNcxseFSdshdwPaHXyutpDksk\npygpSDb5JrCcUDXxHWCUu1dVfSQitaDqIxERKaOSgoiIlMm6AfE6derkhYWF6Q5DRCSrzJ8/f727\nV9eNG8jCpFBYWMi8efPSHYaISFYxs5ruzAdUfSQiInGUFEREpExKk0LUr3xJNC77pATP32VmC6Ll\n/WhgLxERSZOUtSlEd5xOIwwlXALMNbNn3P3d2DHufmXc8ZcDA1IVj4jUzo4dOygpKWH79u3pDkWS\n0KJFC/Lz88nLq2roq+qlsqF5ELAsNmZ6NDvVSMJkIYmMI4z3IiIZpKSkhDZt2lBYWEgYnFYylbuz\nYcMGSkpK6NatW80vSCCV1UddqDgefAlVDHVsZgWE4XRfquL5CWY2z8zmrVu3bo8DmTkTCguhSZPw\nOHOPpqIXady2b99Ox44dlRCygJnRsWPHOpXqMqWheSxhxq2diZ509/vdvcjdizp3rrGbbQUzZ8KE\nCfDRR+AeHidMUGIQ2RNKCNmjrv9WqUwKK6k4SUjZZBsJjCWM8V7vrr0Wtm6tuG/r1rBfREQqSmVS\nmEuYd7WbmTUnmr+18kFm1oMwtvq/UxHExx/XvF/VSyKZa8OGDfTv35/+/fuz//7706VLl7Ltr79O\nbtqF888/nyVLllR7zLRp05hZT3/83/zmN1mwYEG9nKuhpayh2d1LzewyYDZh6r0H3X2Rmd0MzHP3\nWIIYC8zyFI3Md9BBocqosnbtYM0aePHFUJ0UK03EqpcAius87YhI4zNzZiiJf/xx+PubMqVuf0sd\nO3Ys+4K96aabaN26NVdddVWFY9wdd6dJk8S/c6dPn17j+/zwhz+sfZA5JKVtCu7+Z3c/zN0Pdvcp\n0b4b4hIC7n6Tu+92D0N9mTIFWrWquK9JE9i4EfLzKyaEGFUvidROQ7bhLVu2jF69elFcXEzv3r1Z\nvXo1EyZMoKioiN69e3PzzTeXHRv75V5aWkr79u2ZNGkSRxxxBEOGDGHt2rUAXHfddUydOrXs+EmT\nJjFo0CAOP/xw/vWvfwHw5ZdfcsYZZ9CrVy9Gjx5NUVFRjSWCGTNm0LdvX/r06cPkyZMBKC0t5eyz\nzy7bf8899wBw11130atXL/r168f48ePr/ZolI1MamlOmuBjuvx8KCsAsPP7+97B4MVxxxe4JIaaq\naicRqVpDt+G99957XHnllbz77rt06dKFW265hXnz5vHWW2/xwgsv8O67u/eA37RpE8OGDeOtt95i\nyJAhPPjggwnP7e68/vrr3H777WUJ5t5772X//ffn3Xff5frrr+fNN9+sNr6SkhKuu+465syZw5tv\nvsk///lPnnvuOebPn8/69et5++23eeeddzjnnHMAuO2221iwYAELFy7k17/+dR2vTu3kfFKAkBhW\nrIBdu8JjcTH06AG33x6Kt4nE71ebg0hykmnDq08HH3wwRUVFZduPPvooAwcOZODAgSxevDhhUmjZ\nsiUnn3wyAEceeSQrVqxIeO7TTz99t2NeffVVxo4dC8ARRxxB7969q43vtdde4/jjj6dTp07k5eVx\n1lln8corr3DIIYewZMkSJk6cyOzZs2nXrh0AvXv3Zvz48cycObPWN5/VVaNICtX5xS92r14yg1jJ\nTV1aRZKXzI+s+rT33nuXrS9dupS7776bl156iYULFzJ8+PCE/fWbN29ett60aVNKS0sTnnuvvfaq\n8Zja6tixIwsXLuSYY45h2rRpXHzxxQDMnj2bSy65hLlz5zJo0CB27kzYSz+lGn1SqFy9dMABsN9+\n8MtfhvaIyZPV5iCSrERteK1ahf2p9sUXX9CmTRvatm3L6tWrmT17dr2/x9ChQ3nssccAePvttxOW\nROINHjyYOXPmsGHDBkpLS5k1axbDhg1j3bp1uDtnnnkmN998M2+88QY7d+6kpKSE448/nttuu431\n69eztar67RTKuvkUUqG4uGLviM2b4eKL4brrqn6N2hxEdhf7O6rP3kfJGjhwIL169aJHjx4UFBQw\ndOjQen+Pyy+/nHPOOYdevXqVLbGqn0Ty8/P52c9+xrHHHou7c9ppp3HqqafyxhtvcMEFF+DumBm3\n3norpaWlnHXWWWzevJldu3Zx1VVX0aZNm3r/DDXJujmai4qKvCEm2XGHBx4IySGRgoLQPiGS6xYv\nXkzPnj3THUZGKC0tpbS0lBYtWrB06VK+/e1vs3TpUpo1y6zf14n+zcxsvrsXVfGSMpn1STKIWWg7\nWL8+lBjic2dDFYdFJLNs2bKFE044gdLSUtyd3/zmNxmXEOoqtz5NCkyeDJ07w49+BNu2QadOMHWq\nbmwTaYzat2/P/Pnz0x1GSjX6huZkXHQRbNgAQ4aE9oZajkgrIpLxlBSS1LIlPPNMaDgbMQLef7/8\nOd3HICK5QklhD3TqBM8/H778Tz4Z1q7VfQwikluUFPbQwQfDs8/C6tVw2mlwzTW6j0FEcoeSQi0M\nHgyPPAJz58InnyQ+RvcxiNSP4447brcb0aZOncqll15a7etat24NwKpVqxg9enTCY4499lhq6uI+\nderUCjeRnXLKKWzcuDGZ0Kt10003cccdd9T5PPVNSaGWvvc9iAY2TChVt/WLNDbjxo1j1qxZFfbN\nmjWLcePGJfX6Aw88kMcff7zW7185Kfz5z3+mffv2tT5fplNSqIPLLoNTTtl9v+5jEKk/o0eP5k9/\n+lPZhDorVqxg1apVHHPMMWX3DQwcOJC+ffvy9NNP7/b6FStW0KdPHwC2bdvG2LFj6dmzJ6NGjWLb\ntm1lx1166aVlw27feOONANxzzz2sWrWK4447juOOOw6AwsJC1q9fD8Cdd95Jnz596NOnT9mw2ytW\nrKBnz55cdNFF9O7dm29/+9sV3ieRBQsWcPTRR9OvXz9GjRrF559/Xvb+saG0YwPxvfzyy2WTDA0Y\nMIDNmzfX+tomovsU6ujZZ0NX1ddfD9sFBQ13W79IQ7viCqjvCcX69w/3/lRln332YdCgQTz//POM\nHDmSWbNmMWbMGMyMFi1a8OSTT9K2bVvWr1/P0UcfzYgRI6qcp/i+++6jVatWLF68mIULFzJw4MCy\n56ZMmcI+++zDzp07OeGEE1i4cCETJ07kzjvvZM6cOXTq1KnCuebPn8/06dN57bXXcHcGDx7MsGHD\n6NChA0uXLuXRRx/lgQceYMyYMTzxxBPVzo9wzjnncO+99zJs2DBuuOEG/ud//oepU6dyyy238OGH\nH7LXXnuVVVndcccdTJs2jaFDh7JlyxZatGixB1e7Ziop1FGTJvDyyzBgAOy7L8ybp4QgUt/iq5Di\nq47cncmTJ9OvXz9OPPFEVq5cyZo1a6o8zyuvvFL25dyvXz/69etX9txjjz3GwIEDGTBgAIsWLapx\nsLtXX32VUaNGsffee9O6dWtOP/10/vGPfwDQrVs3+vfvD1Q/PDeE+R02btzIsGHDADj33HN55ZVX\nymIsLi5mxowZZXdODx06lB//+Mfcc889bNy4sd7vqFZJoR60aAEPPQRFRXD55fDoo+mOSCQ1qvtF\nn0ojR47kyiuv5I033mDr1q0ceeSRAMycOZN169Yxf/588vLyKCwsTDhcdk0+/PBD7rjjDubOnUuH\nDh0477zzanWemNiw2xCG3q6p+qgqf/rTn3jllVd49tlnmTJlCm+//TaTJk3i1FNP5c9//jNDhw5l\n9uzZ9OjRo9axVqaSQj3p1w+uvx5mzYL/+790RyOSW1q3bs1xxx3H97///QoNzJs2bWLfffclLy+P\nOXPm8FGiCdnjfOtb3+KRRx4B4J133mHhwoVAGHZ77733pl27dqxZs4bnn3++7DVt2rRJWG9/zDHH\n8NRTT7F161a+/PJLnnzySY455pg9/mzt2rWjQ4cOZaWMP/zhDwwbNoxdu3bxySefcNxxx3Hrrbey\nadMmtmzZwgcffEDfvn25+uqrOeqoo3jvvff2+D2ro5JCPZo0CZ58Ei69FIYNg44d0x2RSO4YN24c\no0aNqtATqbi4mNNOO42+fftSVFRU4y/mSy+9lPPPP5+ePXvSs2fPshLHEUccwYABA+jRowddu3at\nMOz2hAkTGD58OAceeCBz5swp2z9w4EDOO+88Bg0aBMCFF17IgAEDqq0qqsrDDz/MJZdcwtatW+ne\nvTvTp09n586djB8/nk2bNuHuTJw4kfbt23P99dczZ84cmjRpQu/evctmkasvGjq7ni1cCEceCWPG\n6K5myQ0aOjv71GXobFUf1bNYNdIjj8BTT4V9GhtJRLKFqo9S4JprQjXSJZfAp5/CT35SPhRGbGwk\nUC8lEck8KimkQF4eTJ8ehtu+6iqNjSTZL9uqmRuzuv5bpTQpmNlwM1tiZsvMbFIVx4wxs3fNbJGZ\nPZLKeBpS//5hxrYvv0z8vMZGkmzRokULNmzYoMSQBdydDRs21OmGtpQ1NJtZU+B94CSgBJgLjHP3\nd+OOORR4DDje3T83s33dfW115830huZ4X38NrVvDjh27P6c5niVb7Nixg5KSkjr125eG06JFC/Lz\n88nLy6uwPxPmaB4ELHP35VFAs4CRQPxtghcB09z9c4CaEkK2ad4cbrpp96oijY0k2SQvL49umm6w\n0Uhl9VEXIH5g6ZJoX7zDgMPM7J9m9h8zG57oRGY2wczmmdm8devWpSjc1Jg8GUaNKt8uKID771cj\ns4hkpnT3PmoGHAocC+QDr5hZX3evMFi5u98P3A+h+qihg6yrWbOgT5/QJfXtt0NDtIhIJkplSWEl\n0DVuOz/aF68EeMbdd7j7h4Q2iENTGFNaNG8Od94JS5bAtGnpjkZEpGqpTApzgUPNrJuZNQfGAs9U\nOuYpQikBM+tEqE5ansKY0ubUU+E73wltDFlWAyYijUjKkoK7lwKXAbOBxcBj7r7IzG42sxHRYbOB\nDWb2LjAH+Km7b0hVTOlkBnfdBVu2hDueRUQykcY+amBXXBGm8XzjjXAvg4hIQ9DYRxnqxhthn31C\ncsiyfCwijYCSQgPr0CHco/Dyy/DEE+mORkSkIiWFNLjwwjCa6lVXhTGSNIKqiGQKJYU0aNoU7r47\njJh68cXh0b18BFUlBhFJFyWFNDn22DDcReVxkTSCqoikk5JCGlUeUjtGI6iKSLooKaRRQUHi/Qcd\n1LBxiIjEKCmk0ZQp0LJlxX0aQVVE0klJIY2Ki+GBB6Bjx7DdqZNGUBWR9FJSSLPiYli7Fo44Atq2\nhTPPTHdEItKYKSlkgCZN4JZbYPnyUFIQEUkXJYUM8Z3vhG6qP/sZbN6c7mhEpLFSUsgQZnDrraEq\n6c470x2NiDRWSgoZZNAgOOMMuOOOkBxERBqakkKGmTIFtm1Tt1QRSQ8lhQxz+OFwwQVw332h4VlE\npCEpKWSgG2+EZs3ghhvSHYmINDZKChnowAPhRz+CRx6BX/xCQ2uLSMPRdJwZauNGyM8P7Qu7dpXv\nb9VKdz2LyJ7TdJxZrn17yMurmBBAQ2uLSGopKWSwjRsT79fQ2iKSKkoKGUxDa4tIQ1NSyGAaWltE\nGpqSQgaLDa29775hu0MHNTKLSGqlNCmY2XAzW2Jmy8xsUoLnzzOzdWa2IFouTGU82ai4GNasgVNO\ngZ074cQT0x2RiOSylCUFM2sKTANOBnoB48ysV4JD/+ju/aPlt6mKJ9vddVfonjp5crojEZFclsqS\nwiBgmbsvd/evgVnAyBS+X0477LBwQ9v06dAIbtMQkTRJZVLoAnwSt10S7avsDDNbaGaPm1nXRCcy\nswlmNs/M5q1bty4VsWaF668P7QsTJ0KW3XMoIlki3Q3NzwKF7t4PeAF4ONFB7n6/uxe5e1Hnzp0b\nNMBM0rYt/PKX8O9/a7gLEUmNVCaFlUD8L//8aF8Zd9/g7l9Fm78FjkxhPDnh3HPhqKPg6qthy5Z0\nRyMiuSaVSWEucKiZdTOz5sBY4Jn4A8zsgLjNEcDiFMaTE5o0gXvugVWrwmB5IiL1KWVJwd1LgcuA\n2YQv+8fcfZGZ3WxmI6LDJprZIjN7C5gInJeqeHLJ0UfD2WfDr34FH3yQ7mhEJJdolNQstWpV6JF0\n4onw1FPpjkZEMp1GSc1xBx4I110HTz8N++2n+RZEpH40S3cAUnv77w9msHZt2P7oI5gwIaxrKAwR\nqQ2VFLLYTTftfr+C5lsQkbpQUshiVc2roPkWRKS2lBSyWFXzKmi+BRGpLSWFLDZlSphfIV7z5ppv\nQURqT0khixUXh/kVYjO07bVXSAoaXltEaktJIcsVF8OKFaHBecEC+PpruPzydEclItlKSSGH9OgB\nN94I//u/8OST6Y5GRLKRkkKO+elPoX9/+MEP4PPP0x2NiGQbJYUck5cHv/sdrFsXEoSIyJ5QUshB\nAweGhPC738GLL6Y7GhHJJkoKOeqGG8KAeRddBF9+me5oRCRbKCnkqJYt4be/DT2Trrsu3dGISLZQ\nUshhxxwDJ50EU6eGgfM0iqqI1ERJIYfNnAmvvlq+HRtFVYlBRKqipJDDrr0Wtm2ruE+jqIpIdZQU\ncphGURWRPaWkkMOqGi21Y8eGjUNEsoeSQg5LNIpqkyawZQssXpyemEQksykp5LD4UVTNwuPUqdC2\nLZx+OmzenO4IRSTTaI7mHFdcvPt8zf36wQknwPnnh8HzzNITm4hknqRKCmZ2sJntFa0fa2YTzax9\nakOTVBk2DG67DZ54Am6/Pd3RiEgmSbb66Algp5kdAtwPdAUeSVlUknJXXgljxsA118Df/pbuaEQk\nUySbFHa5eykwCrjX3X8KHFDTi8xsuJktMbNlZjapmuPOMDM3s6Ik45E6MgsD5vXoAWPHwocfpjsi\nEckEySaFHWY2DjgXeC7al1fdC8ysKTANOBnoBYwzs14JjmsD/Ah4LdmgpX60bh0m49m5M7QxrFyZ\n7ohEJN2STQrnA0OAKe7+oZl1A/5Qw2sGAcvcfbm7fw3MAkYmOO5nwK3A9iRjkXp02GEwezasXx/m\ndl67Nt0RiUg6JZUU3P1dd5/o7o+aWQegjbvfWsPLugCfxG2XRPvKmNlAoKu7/2lPgpb6M3MmnHlm\n6J66ZAkcdZRmbBNpzJLtffR3M2trZvsAbwAPmNmddXljM2sC3An8JIljJ5jZPDObt27durq8rcSZ\nOTMMkPfRR2HbPQyBcdRRuodBpLFKtvqonbt/AZwO/N7dBwMn1vCalYReSjH50b6YNkAf4O9mtgI4\nGngmUWOzu9/v7kXuXtS5c+ckQ5aaXHttGCCvsg8+gNNOS/yciOS2ZJNCMzM7ABhDeUNzTeYCh5pZ\nNzNrDowFnok96e6b3L2Tuxe6eyHwH2CEu89LPnypi+oGxnvlFTjjDPjqq4aLR0TSL9mkcDMwG/jA\n3eeaWXdgaXUviLqwXha9bjHwmLsvMrObzWxEXYKW+lHVgHkFBWF4jL/8Bc46C0pLGzYuEUkfc/d0\nx7BHioqKfN48FSbqQ6xNIb6aqFWrkBCKi8M4SVdeGdanT4e8ajshi0gmM7P57l7jvWDJNjTnm9mT\nZrY2Wp4ws/y6hynplGjAvFhCALjiijDS6syZMHw4bNiQ3nhFJPWSKimY2QuEYS1i9yaMB4rd/aQU\nxpaQSgoN76GH4OKLIT8fnn4a+vRJd0QisqfqtaQAdHb36e5eGi0PAeoG1Eicdx78/e+hmmnIkJAY\nRCQ3JZsUNpjZeDNrGi3jAVUmNCJDhsC8eWGspO99L1QrZVlzlIgkIdmk8H1Cd9RPgdXAaOC8FMUk\nGapLl9BVtbgYrrsuDKT35ZfpjkpE6lOyw1x85O4j3L2zu+/r7t8DzkhxbJJmM2dCYWGYwrOwMGy3\nbAl/+APcemuYoOeb36z+fgcRyS51mY7zx/UWhWSc+CEw3MPjhAlhvxn893/Dc8/B8uUwcKDaGURy\nRV2SgiZxzGGJhsDYujXsjznlFJg7N3Rl/d734JJLVJ0kku3qkhTUzJjDqqoSqrz/sMPg3/8OJYf7\n74cjj4Q33kh9fCKSGtUmBTPbbGZfJFg2Awc2UIySBlUNgZFof/PmoY3hxRdhyxY4+ugwB/SuXamN\nUUTqX7VJwd3buHvbBEsbd2/WUEFKw5syJQx5Ea9Vq7C/KscfDwsXwogRcPXVYdKekpLUxiki9asu\n1UeSw2oaAqMq++wTeiU9+CC8/jr06wcPPxym/BSRzKcB8SRlli2D8ePhtdegd2/4+c9h5MiQZESk\nYdX3MBcie+yQQ+Bf/4I//hF27IBRo0J7w4sv6m5okUylpCC1lujmtsqaNIExY2DRIvjd72D1ajjp\nJDjhhNBrSUQyi5KC1Ep1N7cl0qwZfP/7sHQp3H13SBLf+EZolP7Pf1RyEMkUSgpSK8nc3JbIXnvB\nxIlhHuhf/AL+8Y8w2N6gQaFBevv21MUsIjVTUpBaSfbmtqq0bg3XXBOOnzYt3Al93nnQtStMngyf\nfFJvoYrIHlBSkFrZk5vbqtOmDfzgB6E66cUXYejQcCNcYSGccQbMmaOqJZGGpKQgtVKbm9uqYxYa\nn596KlQt/fSnYWKf44+Hgw+G66+HJUvqHLaI1EBJQWqltje3JaOwEG65JdwN/fvfh66tv/hFmOBn\n0CC4915Yu7bu7yMiu1NSkForLoYVK8IYRytW7J4QkumyWp2WLeHss+Gvfw1tDL/6VbjfYeJEOPBA\n+O534dFHYdOm+vk8IqI7miVFYl1W43sotWpVP6WJd94J5585MySLZs3gW9+C004Ly8EH1+38Irko\n2TualRQkJQoLw70LlRUUhFJFfdi1K9zj8OyzYVm0KOzv0aM8QQwZEpKGSDbavh3WrIFPPw1L377Q\nvXvtzpURScHMhgN3A02B37pt9uF2AAAQeElEQVT7LZWevwT4IbAT2AJMcPd3qzunkkJ2aNIkca8h\ns9QNqb18eZgN7tln4eWXQ1VTu3ahFHHssWE54gho2jQ17y+yJ3bsCD+cPvggLMuXw8qV5Qng009h\n48aKr5k2LfTWq420JwUzawq8D5wElABzgXHxX/pm1tbdv4jWRwA/cPfh1Z1XSSE7NERJoTpffAGz\nZ8MLL4ReTEuXhv1KEtKQduyADz+E998PveeWLi1PAh9/XHH04BYtID8f9t+/fNlvv4rbBx8MHTrU\nLpZkk0IqC9aDgGXuvjwKaBYwEihLCrGEENkbzeaWM6ZMSdymUNsuq3uqbVs488ywQPgF9vLLIUH8\n/e+hNAHhJrqiIhg8uHw5UNNHSZLcYcMGWLUqLB9/XJ4A3n8//PovLS0/fp99whf74MFw1llhPbYc\ncEAoYadbKpNCFyD+vtQSYHDlg8zsh8CPgebA8SmMRxpQrDH52mvDH8pBB4WEUB9dVmujS5fwR3jW\nWWE7liT+9a8w78Odd4ZfdbFjYwmib98w5WhBgdomGoOvvoLPPoPPPy9/jC2ffRYSwOrVIQGsXh2W\nr7+ueI4WLeDQQ8NcIqNHw+GHh/9Dhx0WkkKmS2X10WhguLtfGG2fDQx298uqOP4s4Dvufm6C5yYA\nEwAOOuigIz9KVC8hWWfmzMxJGtu3w4IFYe6H2LJ8efnzeXmhge+ww8IffOyxe/dQ5FfCyA7uoeF2\n+fLEy8qV1b++ffvwi/7AAxMv+flhyYRf/JVlQpvCEOAmd/9OtH0NgLv/sorjmwCfu3u76s6rNoXc\nkMouq/VlwwZ4771QDbB0aXh8//0wedC2beXHNW0axmzq1i20pcQeCwrCF8j++4dqKk0uVP/cQ2Ns\n7Jf7qlXhxsYNG8Kyfn35emyJlQhjunQJyb179/Bvt+++od6+Q4fwyz623r59drc/ZUJSaEZoaD4B\nWEloaD7L3RfFHXOouy+N1k8DbqwpaCWF3JDuhui62LUr/KJ8//0Q64cfhiW2vnr17q9p1apig+H+\n+0OnTmHspzZtQtKIf2zTJnwJdewYSim5zj1U3WzeHDoJfP55+LKPVd3Er69fX151s2pVeF1leXnh\n2iVaunYtTwIFBaG6pzFIe0Ozu5ea2WXAbEKX1AfdfZGZ3QzMc/dngMvM7ERgB/A5sFvVkeSmuo6y\nmk5NmoQvlq5dEz+/fXtIeB99VLGPeWx5773Q2P3ZZ8m9X9u2IYF06hS+1GKP7dqFJJJoadUqJK+v\nvy5fduwoXy8tDb96mzULX6Dxj82ahed27QqL++7rmzeHzxL7fPGPa9aEY1q2DF+48Y8tW4bh07du\nLU8AmzeHpfIv+MqaNQu/2Dt2DCWwb3wjVNnEqnNij/vtp5JZXejmNUmLbC4p1JedO8OQ4Vu2hC/F\nLVvK1zdvDr+OY9Uf69fvvnz5Zbo/QdCpU8Xuk/vtFxLn9u2hmi32GFv/6quQHNq0CQkv/jG23r59\nxWqbDh1CotMXfe2lvaQgUp10d1nNBE2bhi/Atm1r9/qdO8P1iyWT+OXLL8Mv6+bNw5KXV77evHl4\nbufO8Ou8tLT8Mba+c2f4Yo8tZhXXW7cOCaBz58ZRvdWYKClIWiTTZTWTeidloqZNy39di9QXJQVJ\nm+Liqr/kK/dOis0BHXudiKRGBvamFan9HNAiUjdKCpKRsrl3kkg2U1KQjFRfc0CLyJ5RUpCMVNMc\n0HWd1U1EElNSkIxU3RzQsUbojz4KN1PFGqGVGETqTjevSdbRjW8iey7Zm9dUUpCso0ZokdRRUpCs\nk0wjtNocRGpHSUGyTjKN0GpzEKkdJQXJOtU1QoNufBOpCzU0S85p0iSUECozC0M6izRGamiWRktt\nDiK1p6QgOUdtDiK1p6QgOUdtDiK1pzYFaXTU5iCNkdoURKqgNgeRqikpSKOjNgeRqikpSKOjNgeR\nqikpSKNUXBwGz9u1KzzGT/GZzNhKql6SXKWkIFJJTW0Oql6SXKakIFJJTW0Oql6SXKakIFJJTW0O\nGrpbcllKk4KZDTezJWa2zMwmJXj+x2b2rpktNLO/mVlBKuMRSVZ1bQ7JVC+pvUGyVcqSgpk1BaYB\nJwO9gHFm1qvSYW8CRe7eD3gcuC1V8YjUl+qql9TeINkulSWFQcAyd1/u7l8Ds4CR8Qe4+xx3j9XO\n/gfIT2E8IvWiuuoltTdItktlUugCfBK3XRLtq8oFwPOJnjCzCWY2z8zmrVu3rh5DFKmdqqqX1J1V\nsl1GNDSb2XigCLg90fPufr+7F7l7UefOnRs2OJE9oO6sku1SmRRWAl3jtvOjfRWY2YnAtcAId/8q\nhfGIpJy6s0q2S2VSmAscambdzKw5MBZ4Jv4AMxsA/IaQENamMBaRBlEf3VlVvSTp1CxVJ3b3UjO7\nDJgNNAUedPdFZnYzMM/dnyFUF7UG/tfMAD529xGpikmkIRQXV+zCGu+gg0KVUaL9UF69FCtNxKqX\nYucVSbWUtim4+5/d/TB3P9jdp0T7bogSAu5+orvv5+79o0UJQXJafVQvqSQhqZQRDc0ijUVdq5fU\nUC2pppnXRDJIYWHi6qWCgtD1tabnRaqimddEslBN1UtqqJZUU1IQySA1VS/pPghJNSUFkQxT3WB8\ndW2oVilCaqKkIJJF6tJQrVKEJENJQSTL1HZYb3V3lWQoKYjkkOqql9TdVZKhpCCSQ6qrXqqpkVol\nCQElBZGcU1X1Ul27u6ok0TgoKYg0EnXt7qqSROOgpCDSiNSlu6tKEo2DkoKIACpJSKCkICJl0lmS\nUMLIDCmbT0FEckssQVx7bfiiP+igkBDiSxLVzRVRU0lC80hkBpUURCRpqSpJqOopcygpiEi9qEub\nhBqxM4eSgojUm9qWJNSInTmUFESkQVRXkmiI7rBKGkly96xajjzySBeR3DNjhntBgbtZeJwxo/y5\nggL38HVfcSkoSO75GTPcW7Wq+FyrVhXfo7r3zwXAPE/iO1bTcYpIxouVBOKrkFq1Ki9pNGkSvuor\nMwtVWTVNY1rT+XOBpuMUkZxR1xvraqp+0uRE5ZQURCQr1KU7bF2SRmNrr1BSEJGsV1NJoi5JI5lS\nRC51l01pUjCz4Wa2xMyWmdmkBM9/y8zeMLNSMxudylhEJLdVV5KoS9Koa9UTZFlJIpnW6NosQFPg\nA6A70Bx4C+hV6ZhCoB/we2B0MudV7yMRSYWqeh/V1LPJLPHzZuXnzYSeTyTZ+yiVJYVBwDJ3X+7u\nXwOzgJGVEtIKd18I7EphHCIiNart5ER1vfEu09osUpkUugCfxG2XRPv2mJlNMLN5ZjZv3bp19RKc\niEgy6tpeUR89nxqyzSIrGprd/X53L3L3os6dO6c7HBFpZOrSXpHq7rL1LZVJYSXQNW47P9onIpJT\n0tVdNhVSmRTmAoeaWTczaw6MBZ5J4fuJiGScVHaXTYWUJQV3LwUuA2YDi4HH3H2Rmd1sZiMAzOwo\nMysBzgR+Y2aLUhWPiEi6pKq7bCpo7CMRkQw3c2bVM94lK9mxjzQdp4hIhisubriB+bKi95GIiDQM\nJQURESmjpCAiImWUFEREpIySgoiIlMm6Lqlmtg5IMLEeAJ2A9Q0Yzp7K5PgUW+0ottpRbLVTl9gK\n3L3GcYKyLilUx8zmJdMPN10yOT7FVjuKrXYUW+00RGyqPhIRkTJKCiIiUibXksL96Q6gBpkcn2Kr\nHcVWO4qtdlIeW061KYiISN3kWklBRETqQElBRETK5ExSMLPhZrbEzJaZ2aR0xxPPzFaY2dtmtsDM\n0jrut5k9aGZrzeyduH37mNkLZrY0euyQQbHdZGYro2u3wMxOSVNsXc1sjpm9a2aLzOxH0f60X7tq\nYkv7tTOzFmb2upm9FcX2P9H+bmb2WvT3+sdoIq5Mie0hM/sw7rr1b+jY4mJsamZvmtlz0Xbqr5u7\nZ/0CNAU+ALoDzYG3gF7pjisuvhVAp3THEcXyLWAg8E7cvtuASdH6JODWDIrtJuCqDLhuBwADo/U2\nwPtAr0y4dtXElvZrBxjQOlrPA14DjgYeA8ZG+/9/4NIMiu0hYHS6/89Fcf0YeAR4LtpO+XXLlZLC\nIGCZuy9396+BWcDINMeUkdz9FeCzSrtHAg9H6w8D32vQoCJVxJYR3H21u78RrW8mzCbYhQy4dtXE\nlnYebIk286LFgeOBx6P96bpuVcWWEcwsHzgV+G20bTTAdcuVpNAF+CRuu4QM+aOIOPBXM5tvZhPS\nHUwC+7n76mj9U2C/dAaTwGVmtjCqXkpL1VY8MysEBhB+WWbUtasUG2TAtYuqQBYAa4EXCKX6jR6m\n7IU0/r1Wjs3dY9dtSnTd7jKzvdIRGzAV+G9gV7TdkQa4brmSFDLdN919IHAy8EMz+1a6A6qKh3Jp\nxvxaAu4DDgb6A6uBX6UzGDNrDTwBXOHuX8Q/l+5rlyC2jLh27r7T3fsD+YRSfY90xJFI5djMrA9w\nDSHGo4B9gKsbOi4z+y6w1t3nN/R750pSWAl0jdvOj/ZlBHdfGT2uBZ4k/GFkkjVmdgBA9Lg2zfGU\ncfc10R/uLuAB0njtzCyP8KU7093/L9qdEdcuUWyZdO2ieDYCc4AhQHszi00HnPa/17jYhkfVce7u\nXwHTSc91GwqMMLMVhOrw44G7aYDrlitJYS5waNQy3xwYCzyT5pgAMLO9zaxNbB34NvBO9a9qcM8A\n50br5wJPpzGWCmJfuJFRpOnaRfW5vwMWu/udcU+l/dpVFVsmXDsz62xm7aP1lsBJhDaPOcDo6LB0\nXbdEsb0Xl+SNUGff4NfN3a9x93x3LyR8n73k7sU0xHVLd+t6fS3AKYReFx8A16Y7nri4uhN6Q70F\nLEp3bMCjhKqEHYQ6yQsIdZV/A5YCLwL7ZFBsfwDeBhYSvoAPSFNs3yRUDS0EFkTLKZlw7aqJLe3X\nDugHvBnF8A5wQ7S/O/A6sAz4X2CvDIrtpei6vQPMIOqhlK4FOJby3kcpv24a5kJERMrkSvWRiIjU\nAyUFEREpo6QgIiJllBRERKSMkoKIiJRRUhCJmNnOuJExF1g9jrZrZoXxo7+KZKpmNR8i0mhs8zDk\ngUijpZKCSA0szIdxm4U5MV43s0Oi/YVm9lI0cNrfzOygaP9+ZvZkNE7/W2b2jehUTc3sgWjs/r9G\nd9FiZhOjuRAWmtmsNH1MEUBJQSRey0rVR/8V99wmd+8L/JoweiXAvcDD7t4PmAncE+2/B3jZ3Y8g\nzA+xKNp/KDDN3XsDG4Ezov2TgAHReS5J1YcTSYbuaBaJmNkWd2+dYP8K4Hh3Xx4NPPepu3c0s/WE\noSN2RPtXu3snM1sH5HsYUC12jkLC0MyHRttXA3nu/nMz+wuwBXgKeMrLx/gXaXAqKYgkx6tY3xNf\nxa3vpLxN71RgGqFUMTduFEyRBqekIJKc/4p7/He0/i/CCJYAxcA/ovW/AZdC2SQu7ao6qZk1Abq6\n+xzCuP3tgN1KKyINRb9IRMq1jGbhivmLu8e6pXYws4WEX/vjon2XA9PN7KfAOuD8aP+PgPvN7AJC\nieBSwuiviTQFZkSJw4B7PIztL5IWalMQqUHUplDk7uvTHYtIqqn6SEREyqikICIiZVRSEBGRMkoK\nIiJSRklBRETKKCmIiEgZJQURESnz/wCOBjd9BGQ5PgAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "uWTEWhHAxrPq",
+        "outputId": "26a50a1a-f588-4c33-9a33-857a3d2c7f6f",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 295
+        }
+      },
+      "source": [
+        "plt.clf()   # clear figure\n",
+        "acc_values = history_dict['acc']\n",
+        "val_acc_values = history_dict['val_acc']\n",
+        "\n",
+        "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
+        "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",
+        "plt.title('Training and validation accuracy')\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Accuracy')\n",
+        "plt.legend()\n",
+        "\n",
+        "plt.show()"
+      ],
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEWCAYAAACXGLsWAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3XmcVNWZ//HPQ8suAgJu7CgKzd52\nUOO+g3GJqCOKv7hEiUaNcfk5JBhxjOj8ogbjxEkGM8YNJURHxdFoXFA00YRWFkFEEFkaEVpAlH3p\n5/fHudVd3VRXVS/VVd39fb9e91V3r6dudd+nzjn3nmvujoiISDLNsh2AiIjkPiULERFJSclCRERS\nUrIQEZGUlCxERCQlJQsREUlJyULSZmZ5ZrbJzHrU5brZZGaHmFmdXz9uZqeY2bK46UVmdmw669bg\nvf5gZj+v6fYi6dgr2wFI5pjZprjJNsB2YHc0/SN3n1Kd/bn7bmDvul63KXD3w+piP2Z2JXCJu58Q\nt+8r62LfIskoWTRi7l52so5+uV7p7q9Xtb6Z7eXuu+ojNpFU9PeYW1QN1YSZ2V1m9icze9rMvgUu\nMbOjzOx9M/vazFab2YNm1jxafy8zczPrFU0/GS3/i5l9a2bvmVnv6q4bLR9pZp+a2UYz+w8z+5uZ\nXVZF3OnE+CMzW2JmG8zswbht88xskpmtM7OlwIgkx2e8mU2tNO8hM/t1NH6lmS2MPs9n0a/+qvZV\nbGYnRONtzOyJKLYFwOGV1r3NzJZG+11gZmdH8wcBvwWOjar4voo7tnfEbX919NnXmdnzZnZgOsem\nOsc5Fo+ZvW5m683sSzO7Ne59fhEdk2/MrMjMDkpU5Wdm78a+5+h4zozeZz1wm5n1NbMZ0Xt8FR23\n9nHb94w+Y0m0/Ddm1iqKuX/cegea2RYz61TV55UU3F1DExiAZcAplebdBewAziL8cGgNfAc4glDq\n7AN8ClwXrb8X4ECvaPpJ4CugEGgO/Al4sgbr7gd8C5wTLbsJ2AlcVsVnSSfGF4D2QC9gfeyzA9cB\nC4BuQCdgZvg3SPg+fYBNQNu4fa8FCqPps6J1DDgJ2AoMjpadAiyL21cxcEI0fh/wFtAR6Al8XGnd\nfwEOjL6Ti6MY9o+WXQm8VSnOJ4E7ovHTohiHAq2A/wTeTOfYVPM4twfWADcALYF9gOHRsp8Bc4G+\n0WcYCuwLHFL5WAPvxr7n6LPtAq4B8gh/j4cCJwMtor+TvwH3xX2e+dHxbButf3S0bDIwMe59bgae\ny/b/YUMesh6Ahnr6oqtOFm+m2O4W4M/ReKIE8Pu4dc8G5tdg3SuAd+KWGbCaKpJFmjEeGbf8f4Bb\novGZhOq42LIzKp/AKu37feDiaHwksCjJuv8LXBuNJ0sWK+K/C+DH8esm2O984HvReKpk8Rhwd9yy\nfQjtVN1SHZtqHuf/A8yqYr3PYvFWmp9OsliaIobzY+8LHAt8CeQlWO9o4HPAouk5wKi6/r9qSoOq\noWRl/ISZ9TOzl6JqhW+AO4HOSbb/Mm58C8kbtata96D4ODz8dxdXtZM0Y0zrvYDlSeIFeAq4KBq/\nOJqOxXGmmf0jqiL5mvCrPtmxijkwWQxmdpmZzY2qUr4G+qW5Xwifr2x/7v4NsAHoGrdOWt9ZiuPc\nnZAUEkm2LJXKf48HmNk0M1sVxfBopRiWebiYogJ3/xuhlHKMmQ0EegAv1TAmQW0WEn5pxvsvwi/Z\nQ9x9H+B2wi/9TFpN+OULgJkZFU9uldUmxtWEk0xMqkt7pwGnmFlXQjXZU1GMrYFngHsIVUQdgL+m\nGceXVcVgZn2A3xGqYjpF+/0kbr+pLvP9glC1FdtfO0J116o04qos2XFeCRxcxXZVLdscxdQmbt4B\nldap/Pn+H+EqvkFRDJdViqGnmeVVEcfjwCWEUtA0d99exXqSBiULqawdsBHYHDUQ/qge3vN/gQIz\nO8vM9iLUg3fJUIzTgJ+aWdeosfNfk63s7l8SqkoeJVRBLY4WtSTUo5cAu83sTELderox/NzMOli4\nD+W6uGV7E06YJYS8eRWhZBGzBugW39BcydPAD81ssJm1JCSzd9y9ypJaEsmO83Sgh5ldZ2YtzWwf\nMxseLfsDcJeZHWzBUDPbl5AkvyRcSJFnZmOJS2xJYtgMbDSz7oSqsJj3gHXA3RYuGmhtZkfHLX+C\nUG11MSFxSC0oWUhlNwOXEhqc/4vQEJ1R7r4GuBD4NeGf/2BgNuEXZV3H+DvgDeAjYBahdJDKU4Q2\niLIqKHf/GrgReI7QSHw+IemlYwKhhLMM+AtxJzJ3nwf8B/DPaJ3DgH/EbfsasBhYY2bx1Umx7V8h\nVBc9F23fAxiTZlyVVXmc3X0jcCpwHiGBfQocHy2+F3iecJy/ITQ2t4qqF68Cfk642OGQSp8tkQnA\ncELSmg48GxfDLuBMoD+hlLGC8D3Eli8jfM/b3f3v1fzsUkms8UckZ0TVCl8A57v7O9mORxouM3uc\n0Gh+R7Zjaeh0U57kBDMbQbjyaCvh0sudhF/XIjUStf+cAwzKdiyNgaqhJFccAywl1NWfDpyrBkmp\nKTO7h3Cvx93uviLb8TQGqoYSEZGUVLIQEZGUGk2bRefOnb1Xr17ZDkNEpEH54IMPvnL3ZJeqA40o\nWfTq1YuioqJshyEi0qCYWapeDABVQ4mISBqULEREJCUlCxERSanRtFkksnPnToqLi9m2bVu2Q5Ek\nWrVqRbdu3WjevKrujkQk2xp1siguLqZdu3b06tWL0JGp5Bp3Z926dRQXF9O7d+/UG4hIVjTqaqht\n27bRqVMnJYocZmZ06tRJpT+RGpgyBXr1gmbNwuuUKZl7r0ZdsgCUKBoAfUci1TdlCowdC1u2hOnl\ny8M0wJia9jOcRKMuWYiI5LJUJYNky8ePL08UMVu2hPmZoGSRQevWrWPo0KEMHTqUAw44gK5du5ZN\n79ixI619XH755SxatCjpOg899BBTMln+FJEaq+qEHysZLF8O7uUlg3SXr6iie8Sq5tdath8CXlfD\n4Ycf7pV9/PHHe8xL5skn3Xv2dDcLr08+Wa3Nk5owYYLfe++9e8wvLS313bt3190bNVDV/a5EckWy\n88aTT7q3aeMeTvdhaNOmfJv4+bGhZ8+wbW2Xpwso8jTOsSpZRFJl8bq0ZMkS8vPzGTNmDAMGDGD1\n6tWMHTuWwsJCBgwYwJ133lm27jHHHMOcOXPYtWsXHTp0YNy4cQwZMoSjjjqKtWvXAnDbbbfxwAMP\nlK0/btw4hg8fzmGHHcbf/x4eELZ582bOO+888vPzOf/88yksLGTOnDl7xDZhwgS+853vMHDgQK6+\n+mo86pX4008/5aSTTmLIkCEUFBSwbNkyAO6++24GDRrEkCFDGJ+p8q9IFiWrCkp13khWVZSqZJBq\n+cSJ0KZNxWVt2oT5GZFORmkIQ21LFnWVpasSX7JYvHixm5nPmjWrbPm6devc3X3nzp1+zDHH+IIF\nC9zd/eijj/bZs2f7zp07HfCXX37Z3d1vvPFGv+eee9zdffz48T5p0qSy9W+99VZ3d3/hhRf89NNP\nd3f3e+65x3/84x+7u/ucOXO8WbNmPnv27D3ijMVRWlrqo0ePLnu/goICnz59uru7b9261Tdv3uzT\np0/3Y445xrds2VJh25pQyUKypaYlA/fU5w2zxMtj71XbkkNd1IagkkX11Hf938EHH0xhYWHZ9NNP\nP01BQQEFBQUsXLiQjz/+eI9tWrduzciRIwE4/PDDy37dVzZq1Kg91nn33XcZPXo0AEOGDGHAgAEJ\nt33jjTcYPnw4Q4YM4e2332bBggVs2LCBr776irPOOgsIN9G1adOG119/nSuuuILWrVsDsO+++1b/\nQIhkWKZKBpD6vNGjR+LlPXqkLhmkU3IYMwaWLYPS0vCaiaugYpQsIsm+1Exo27Zt2fjixYv5zW9+\nw5tvvsm8efMYMWJEwvsOWrRoUTael5fHrl27Eu67ZcuWKddJZMuWLVx33XU899xzzJs3jyuuuEL3\nP0iDUNNG5EwmA0h+wh8zBiZPhp49wSy8Tp5cfsJPtby+KVlE6r3+L84333xDu3bt2GeffVi9ejWv\nvvpqnb/H0UcfzbRp0wD46KOPEpZctm7dSrNmzejcuTPffvstzz77LAAdO3akS5cuvPjii0C42XHL\nli2ceuqpPPLII2zduhWA9evX13ncIqkkSwjZTAaQXkJIVjKoz5JDKkoWkWxm8YKCAvLz8+nXrx8/\n+MEPOProo+v8Pa6//npWrVpFfn4+//Zv/0Z+fj7t27evsE6nTp249NJLyc/PZ+TIkRxxxBFly6ZM\nmcL999/P4MGDOeaYYygpKeHMM89kxIgRFBYWMnToUCZNmlTncYtAze83yHYyiK2TKyf8WkmnYaMh\nDHVx6WxjtnPnTt+6dau7u3/66afeq1cv37lzZ5ajKqfvqmmrTSNzbRqRU+07VWyNAWk2cGf9JF9X\ng5JFchs2bPCCggIfPHiwDxo0yF999dVsh1SBvqvGLZNXHCVbrmSQmpKF6wTUkOi7arwyeflpOvtv\n6skglXSThdosRKTWatOHUW3bFWrbiCzpUbIQkVqpbR9GtW1kBiWE+qBkISJpqar0kKrkUB9XHEnm\nZTRZmNkIM1tkZkvMbFyC5T3N7A0zm2dmb5lZt7hlu81sTjRMz2ScIlLzO51r24dRk7r8tCFLp2Gj\nJgOQB3wG9AFaAHOB/Err/Bm4NBo/CXgibtmm6rxfLjZwn3DCCf7KK69UmDdp0iS/+uqrk27Xtm1b\nd3dftWqVn3feeQnXOf744yv0LZXIpEmTfPPmzWXTI0eO9A0bNqQTer3L9nfV1NWmEbq++jCSzCAH\nGriHA0vcfam77wCmAudUWicfeDMan5FgeYN20UUXMXXq1Arzpk6dykUXXZTW9gcddBDPPPNMjd//\ngQceYEtc/cDLL79Mhw4darw/adgy1QitNoWmIZPJoiuwMm66OJoXby4wKho/F2hnZp2i6VZmVmRm\n75vZ9xO9gZmNjdYpKikpqcvY68T555/PSy+9VPago2XLlvHFF19w7LHHsmnTJk4++WQKCgoYNGgQ\nL7zwwh7bL1u2jIEDBwKhK47Ro0fTv39/zj333LIuNgCuueaasu7NJ0yYAMCDDz7IF198wYknnsiJ\nJ54IQK9evfjqq68A+PWvf83AgQMZOHBgWffmy5Yto3///lx11VUMGDCA0047rcL7xLz44oscccQR\nDBs2jFNOOYU1a9YAsGnTJi6//HIGDRrE4MGDy7oLeeWVVygoKGDIkCGcfPLJdXJspXoy2QitNoUm\nIp3iR00G4HzgD3HT/wf4baV1DgL+B5gN/IaQUDpEy7pGr32AZcDByd4vVTXUDTe4H3983Q433JC6\niPe9733Pn3/+eXcP3YTffPPN7h7uqN64caO7u5eUlPjBBx/spaWl7l5eDfX555/7gAED3N39/vvv\n98svv9zd3efOnet5eXll1VCxrsF37drlxx9/vM+dO9fd3Xv27OklJSVlscSmi4qKfODAgb5p0yb/\n9ttvPT8/3z/88EP//PPPPS8vr6zr8gsuuMCfeOKJPT7T+vXry2J9+OGH/aabbnJ391tvvdVviDso\n69ev97Vr13q3bt186dKlFWKtTNVQtZesqqe23WGnc3ObNEzkQDXUKqB73HS3aF4Zd//C3Ue5+zBg\nfDTv6+h1VfS6FHgLGJbBWDMmvioqvgrK3fn5z3/O4MGDOeWUU1i1alXZL/REZs6cySWXXALA4MGD\nGTx4cNmyadOmUVBQwLBhw1iwYEHCTgLjvfvuu5x77rm0bduWvffem1GjRvHOO+8A0Lt3b4YOHQpU\n3Q16cXExp59+OoMGDeLee+9lwYIFALz++utce+21Zet17NiR999/n+OOO47evXsD6sY8U2pbctAV\nSZLKXhnc9yygr5n1JiSJ0cDF8SuYWWdgvbuXAj8DHonmdwS2uPv2aJ2jgV/VJpiopqXenXPOOdx4\n4418+OGHbNmyhcMPPxwIHfOVlJTwwQcf0Lx5c3r16lWj7sA///xz7rvvPmbNmkXHjh257LLLatWt\neKx7cwhdnCeqhrr++uu56aabOPvss3nrrbe44447avx+kr5YL6orVpQ/DyF2sk7W5jBmTFh/+fI9\n9xl/Y1tsP4n2H1tHyaHpyljJwt13AdcBrwILgWnuvsDM7jSzs6PVTgAWmdmnwP5ArEmsP1BkZnMJ\nDd//7u7Jfy7nqL333psTTzyRK664okLD9saNG9lvv/1o3rw5M2bMYHmi/+Q4xx13HE899RQA8+fP\nZ968eUDo3rxt27a0b9+eNWvW8Je//KVsm3bt2vHtt9/usa9jjz2W559/ni1btrB582aee+45jj32\n2LQ/08aNG+naNTQ/PfbYY2XzTz31VB566KGy6Q0bNnDkkUcyc+ZMPv/8c0DdmNdUpksOoEZoSS6j\n91m4+8vufqi7H+zuE6N5t7v79Gj8GXfvG61zpbtvj+b/3d0HufuQ6PW/Mxlnpl100UXMnTu3QrIY\nM2YMRUVFDBo0iMcff5x+/fol3cc111zDpk2b6N+/P7fffntZCWXIkCEMGzaMfv36cfHFF1fo3nzs\n2LGMGDGirIE7pqCggMsuu4zhw4dzxBFHcOWVVzJsWPq1fHfccQcXXHABhx9+OJ07dy6bf9ttt7Fh\nwwYGDhzIkCFDmDFjBl26dGHy5MmMGjWKIUOGcOGFF6b9PlKutje+qRpJastC+0bDV1hY6EVFRRXm\nLVy4kP79+2cpIqkOfVdBVVVNzZqFEkVlZqEkECt5xCeUNm2UECQ1M/vA3QtTrZfJNgsRqYbKJ/xY\nVRPUTZuDSG2obyiRelTTG+PU5iDZ1uiTRWOpZmvMmsp3VJtGarU5SLY16mTRqlUr1q1b12RORg2R\nu7Nu3TpatWqV7VAyri4aqVVykGxp1G0W3bp1o7i4mFzsCkTKtWrVim7duqVesQFIdi9EOpe3Jmqk\njq9qEsmWRp0smjdvXnbnsEimJWugrqsb40SypVFfOitSn3r1SpwMevYM1Ua6vFVyUbqXzjbqNguR\nupbsaqZU1UxqpJaGTMlCJE5NnxYHqRuoQY3U0nApWYhEUiWDVFczpXMvhEhDpWQhEqnN0+JA1UzS\nuDXqq6FEqiOdp8Ulu5oJ1I23NF4qWUiTU1W7RKo2B1UzSVOmZCFNSrJ2CT0tTqRqShbS6NS0s750\nkoGuZpKmSjflSaOS6sa3VM+FEGlqdFOeNEm17axPRBJTspBGpS6eRS0ie1KykAYnWZuEnkUtkhlK\nFtKgpLrLWk+UE8kMJQvJOTW9mglUchDJFF0NJTlFVzOJ1K+cuBrKzEaY2SIzW2Jm4xIs72lmb5jZ\nPDN7y8y6xS271MwWR8OlmYxTcoeuZhLJTRlLFmaWBzwEjATygYvMLL/SavcBj7v7YOBO4J5o232B\nCcARwHBggpl1zFSskjt0NZNIbspkyWI4sMTdl7r7DmAqcE6ldfKBN6PxGXHLTwdec/f17r4BeA0Y\nkcFYpR7paiaRhieTyaIrsDJuujiaF28uMCoaPxdoZ2ad0twWMxtrZkVmVlRSUlJngUvm6GomkYYp\n21dD3QIcb2azgeOBVcDudDd298nuXujuhV26dMlUjFKHdDWTSMOUyWSxCugeN90tmlfG3b9w91Hu\nPgwYH837Op1tJbdVVdWUqk0CVHIQyUWZfPjRLKCvmfUmnOhHAxfHr2BmnYH17l4K/Ax4JFr0KnB3\nXKP2adFyaQAqX/4aq2qC9B4gJCK5J2MlC3ffBVxHOPEvBKa5+wIzu9PMzo5WOwFYZGafAvsDE6Nt\n1wO/JCScWcCd0TxpAJJVNelqJpGGSTflSZ1LdePclCkhcaxYEUoUEyeqqkkkW3LipjxpvGp7+ava\nJEQalky2WUgjlaxNYsyYUFJI1GWHqpokmXXr4IsvYOtW2Lat/DV+PC8PWreGVq3KX2PjbdrAwQdD\n8+bZ/iSNk6qhpNp69UrcSN2zZygpgKqa6os7fPUVLFkCn30WXtesgV27YOfO8Bo/7NwJ++8PhYVh\nGDw4nGxT2bABPv447H/XrlCibNYsnLxj482aQYsWcNBB4Tvfb78wL5Fdu2D+fHjvPXj//fC6eHHt\nj0fr1uFzHXkkHHVUeD3wwD3X274dPvkE5s0rH9avh759oV+/8qFv37DPZEpL4dtvw3iLFmHIy6v9\nZ6kv6VZDKVlItakzv+rbvRtKSmD16jCsXx9OwLHh66/Lx7/5Blq2DL+U27bd89UdPv+8PDnETlQQ\nvoNOncIJa6+9Kg7Nm4eT2IoVIcFAmDdoUHnyKCiATZtCYogfvvyy+p+5RQvo2jUkju7dw1BaCv/4\nB8yaBZs3h/X226/8xH7IIVWXHFq2DMcxVtqoXPrYuBE+/DAknw8/hB07wv579gz77tcvJKR580Ki\n2LUrLG/ZEgYOhH33DctjN4zGjmfPnmHbffYJ383GjWGIjccf/5i8vPD5W7Ysf+3UKSTqqoaOHcPQ\ntm143/qiZCEZk07JojHYti2ckD/9NAyLF5ePb9gQTh7t25cP8dPbtpUnhi++gLVrw4kukb33DieJ\nDh3C6z77hBLA5s2hKq/y6+7d4Ts45JBQ7XLIIeXjvXuHE1My7iFhFBVVHL7+es+48vMrDoceGk7e\npaVh2L27fLy0NJy8V62ClSvDe6xcWT6+alU4CQ4dWp4cjjoqfJa6Pjlu2wZz5lQsuaxcGRLX4MEV\nh759QzKN2bIlfNeLFoWkEhs2bar6+27XLvyI2rGjfNi+vXx827aQoNesCYl3zZryZFbZXnuV/y3E\n/i7atw9JJPajofIPiIMOgtNOq9mxUrKQjEnVjXhD5B5+Qb/9NsycGX79xv/ChPAL+NBDw9CpU/hF\nGf8LM368RYtQ/XHggeEfOTYeGzp3DieBDh1yo47dPSTG2bPDiSk/P5QK6vIkvnt3+DWfKpllyrZt\n6VW51Qf38HeyZk0Y1q5NXMqMTW/cWPEHw7ZtFfd35JEhIdZEuslCDdySULI2h9hrQ26T2L0bPvoo\nJIe334Z33imvmunaFY4+Gi67LPzqPPTQ8Nq+fVZDziiz8hJKpuTlZbcuP1cSBYTjHfuxcNhh1d9+\n9+5QioslkPqotlLJQvbQWEoOO3aE0sHSpaGOP/51yZJQCoBQDXL88eVD7971W2cskk2qhpIaa0ht\nEu6hTeCTTyrWMS9aFOqo4/+8W7QIiaB3b+jTJxTdjz9eXY1I06ZqKKmxdDr7y7TVq0M1UVVtAhs3\nhoS2aFFoeIxp1y4U6489NlSp9OlTnhwOPLDqSzlFJDklC9lDNjr7cw8lghdegOefDw3MibRrV34l\nSteucPnlFa+LP/BAVSGJZIKSheyhvu7A3r07JIXnnw9J4tNPw/zvfAfuuiuUDjp2LL88ce+9G9bN\nTiKNiZJFE5XNq51Wr4YHH4RHHgmXDDZvDieeCD/9KZx9digxiEhuUbJoglL17RR7resrnxYuhPvv\nhyeeCNfbn302XHghjBzZuC9LFWkMdDVUE1SfVzu5w7vvwr33wosvhm4bLr8cbrop3HEsItmlq6Gk\nSvVxtdPWrfDSS3DffaFdolMnmDABrr0W9Lh0kYZHyaIJysTVTrHuMl59NQwzZ4YuCfr0gd/+NpQm\nKj8hT0QaDiWLJqiurnbasAFeey0kh7/+FYqLw/z+/eHqq2HECDjlFF3BJNIYKFk0QbW92mnHjtBQ\n/ctfhuqm9u1DUrj9djj9dN0RLdIYKVk0UTW92umtt+DHPw5XNo0aBTffDMOHV+ziWUQaH3V+IGlZ\nuxZ+8INwP8S2baHx+tln4bvfVaIQaQqULCSp3bvh978P/S1NnRqqrubPhzPOyHZkIlKflCwaqSlT\nwv0UzZqF1ylTqr+P2bNDyeGaa2DYsPA4yrvu0lVNIk1RRpOFmY0ws0VmtsTMxiVY3sPMZpjZbDOb\nZ2ZnRPN7mdlWM5sTDb/PZJyNTewO7diT3mJ3aKebMDZtCm0RhYVh2yefhDfeCB31iUjTlDJZmNn1\nZtaxujs2szzgIWAkkA9cZGb5lVa7DZjm7sOA0cB/xi37zN2HRsPV1X3/pmz8+IqXxUKYHj8+9bYv\nvQQDBsCvfw1XXRV6gh0zRj25ijR16ZQs9gdmmdm0qKSQ7mljOLDE3Ze6+w5gKnBOpXUc2Ccabw98\nkea+JYma3KG9ejX8y7/AmWeG3l3ffTe0VXTokJkYRaRhSZks3P02oC/w38BlwGIzu9vMUvXs0xVY\nGTddHM2LdwdwiZkVAy8D18ct6x1VT71tZscmegMzG2tmRWZWVFJSkuqjNBlV3eeQaH5paUgK/fvD\n9OmhTWL27PAMahGRmLTaLDz0NvhlNOwCOgLPmNmvavn+FwGPuns34AzgCTNrBqwGekTVUzcBT5nZ\nPpU3dvfJ7l7o7oVd1OFQmYkT92yETnSH9sKF4ZkR11wDhx8enkw3fnx4/KiISLx02ixuMLMPgF8B\nfwMGufs1wOHAeUk2XQV0j5vuFs2L90NgGoC7vwe0Ajq7+3Z3XxfN/wD4DDg0rU8kjBkDkyeHXmTN\nwuvkyeU34bnDH/4QEsSiRfDYY/D669C3b3bjFpHclc7tVPsCo9y9Qtdz7l5qZmcm2W4W0NfMehOS\nxGjg4krrrABOBh41s/6EZFFiZl2A9e6+28z6EKrBlqb1iQSo+g7tjRvhRz+CP/0pdNHxxBNwwAH1\nH5+INCzpVEP9BVgfmzCzfczsCAB3X1jVRu6+C7gOeBVYSLjqaYGZ3WlmZ0er3QxcZWZzgaeBy6Iq\nr+OAeWY2B3gGuNrd1+/5LlIds2ZBQQE88wzcc0/oAFCJQkTSkfLhR2Y2GyiITuJEbQpF7l5QD/Gl\nTQ8/qlppKUyaBOPGwUEHwdNPh5vtRETSffhROiUL87iM4u6lqAPCrEv3Du2SEjjrLLjllvA6Z44S\nhYhUXzrJYqmZ/cTMmkfDDaj9IKvSvUP7gw9gyJBw9/VDD4WO/zpW+/ZKEZH0ksXVwHcJjdTFwBHA\n2EwGJcmlc4d2cXG4wa55c3j//dCtuO7CFpGaSlmd5O5rCVcySY5IdYf2li3w/e+HPp7eew8GDqy/\n2ESkcUqZLMysFeF+iAGES1s72zwdAAASo0lEQVQBcPcrMhiXJJHsGdrucMUV8OGH8MILShQiUjfS\nqYZ6AjgAOB14m3Bz3beZDEqSS3aH9sSJ4R6Ke+4JDdoiInUhnWRxiLv/Atjs7o8B3yO0W0iWVHWH\ndps28ItfwCWXwK23ZjtKEWlM0rkEdmf0+rWZDST0D7Vf5kKSdFS+Q3vu3HBJ7BFHwMMPqzFbROpW\nOslicvQ8i9uA6cDewC8yGpVUy9q1cPbZ4bLY556DVq1SbyMiUh1Jk0V0t/Y37r4BmAn0qZeoJG3b\nt8OoUeHmu3fegQMPzHZEItIYJW2ziO7WVu13jnIP3Yv/7W/w6KOhF1kRkUxIp4H7dTO7xcy6m9m+\nsSHjkUlSpaXhOdl//CPcfnt4yp2ISKak02ZxYfR6bdw8R1VSWbNzJ1x5JTz+ONxwA0yYkO2IRKSx\nS+exqr0TDEoU9SBRZ4Fbt8J554VE8ctfht5km6X1vEMRkZpLp4vyHySa7+6PZySiGmpsXZTHOguM\n7wOqdetwT8WiRaFjwGuuyV58ItI4pNtFeTrVUN+JG29FeLLdh0BOJYvGJlFngVu3wiefhOdRjFZv\nXSJSj9LpSPD6+Gkz6wBMzVhEAlTdWSAoUYhI/atJbfdmoHddByIV9eiReH7PnvUbh4gIpNfr7IuE\nq58gJJd8YFomg5LQIeBVV4Wqp5hYZ4EiIvUtnTaL++LGdwHL3b04Q/FIZMyY0MX4n/8cpnv2DIki\nvj8oEZH6kk6yWAGsdvdtAGbW2sx6ufuyjEbWxG3fDjNnwumnwyuvZDsaEWnq0mmz+DNQGje9O5on\nGTRlCqxZA7fcku1IRETSSxZ7ufuO2EQ03iKdnZvZCDNbZGZLzGxcguU9zGyGmc02s3lmdkbcsp9F\n2y0ys9PTeb/GorQU7rsPhg6Fk0/OdjQiIuklixIzOzs2YWbnAF+l2sjM8oCHgJGERvGLzCy/0mq3\nAdPcfRjhOd//GW2bH00PAEYA/xntr0n4y19g4cJQqtBzKUQkF6STLK4Gfm5mK8xsBfCvwI/S2G44\nsMTdl0alkanAOZXWcWCfaLw98EU0fg4w1d23u/vnwJJof03CvfdC9+7qHFBEckc6fUN95u5HEkoH\n+e7+XXdfksa+uwIr46aLo3nx7gAuMbNi4GUgdgNgOts2eIn6fpo1C95+G376U2jePNsRiogEKZOF\nmd1tZh3cfZO7bzKzjmZ2Vx29/0XAo+7eDTgDeCJ64FJazGysmRWZWVFJSUkdhVQ/Yn0/LV8enkux\nfHmYvv562Gef0KusiEiuSOfEPNLdv45NRE/NOyPJ+jGrgO5x092iefF+SHSDn7u/R+h7qnOa2+Lu\nk9290N0Lu3TpkkZIuSNR309btsA//gFXXx0ShohIrkgnWeSZWcvYhJm1BlomWT9mFtDXzHqbWQtC\ng/X0SuusIHRMiJn1JySLkmi90WbW0sx6A32Bf6bxng1Gsr6ffvKT+otDRCQd6dyUNwV4w8z+CBhw\nGfBYqo3cfZeZXQe8CuQBj7j7AjO7Eyhy9+nAzcDDZnYjobH7Mg99pi8ws2nAx4S7xq91993V/3i5\nq0ePUPVUWdu20LXRtc6ISEOX8nkWEO6XAE4hnNC/AQ5w92uTb1W/GtrzLBI9rwLgnntg3B53pIiI\nZEa6z7NItzF5DSFRXACcBCysRWxC6ONp8uTyXmSbNYNBg5QoRCQ3VZkszOxQM5tgZp8A/0FoXzB3\nP9Hdf1tvETZiY8bAsmXwhz+Eu7YnTcp2RCIiiSVrs/gEeAc4M3ZfRdS2IHUovmuPk07KdjQiIokl\nq4YaBawGZpjZw2Z2MqGBW+rQyy+HR6Wqaw8RyWVVJgt3f97dRwP9gBnAT4H9zOx3ZnZafQXY2N1/\nv7r2EJHcl053H5vd/Sl3P4twc9xsQv9QUksrV8Jbb4WrotS1h4jksmo9g9vdN0R3Tavj7Drw7LPh\nVaUKEcl11UoWUrf+/GcYPBgOPTTbkYiIJKdkkSUrV8Lf/65ShYg0DEoWWRKrgrrgguzGISKSDiWL\nLFEVlIg0JEoWGZTo4UagKigRaXjS6XVWaqByR4GxhxsBxJ7TpCooEWkolCwypKqHG40fH7ogVxWU\niDQkqobKkKoebrR8uaqgRKThUbLIkB49Es/v2DG8qgpKRBoSJYsMmTgR2rSpOK9NG+jcWVVQItLw\nKFlkSPzDjczC6z33wOLFqoISkYZHySKDYg83Ki0tfwVVQYlIw6NkUQtV3UdRFd2IJyINlZJFDcXu\no1i+HNzL76OoKmHoRjwRaciULGoo2X0UiagvKBFpyJQsaqiq+yiqmq8qKBFpyDKaLMxshJktMrMl\nZjYuwfJJZjYnGj41s6/jlu2OWzY9k3HWRFX3USSaryooEWnoMtbdh5nlAQ8BpwLFwCwzm+7uH8fW\ncfcb49a/HhgWt4ut7j40U/HV1sSJFft+gnAfxcSJe66rKigRaegyWbIYDixx96XuvgOYCpyTZP2L\ngKczGE+dSnQfxeTJYX5lqoISkYYuk8miK7Aybro4mrcHM+sJ9AbejJvdysyKzOx9M/t+5sKsucr3\nUSRKFKqCEpHGIFd6nR0NPOPuu+Pm9XT3VWbWB3jTzD5y98/iNzKzscBYgB5VNSJkwfbtUFwcEsWf\n/hTmqQpKRBqyTCaLVUD3uOlu0bxERgPXxs9w91XR61Ize4vQnvFZpXUmA5MBCgsLvU6irqbFi+F3\nvwv3WaxYERLEmjUV1znySFVBiUjDlslkMQvoa2a9CUliNHBx5ZXMrB/QEXgvbl5HYIu7bzezzsDR\nwK8yGGuNfPwxnHgibNwIffpA9+4wZEi4Iqp79zD06BHu7hYRacgylizcfZeZXQe8CuQBj7j7AjO7\nEyhy99jlsKOBqe4eXzLoD/yXmZUS2lX+Pf4qqlwQSxTNmsGcOdCvX7YjEhHJHKt4jm64CgsLvaio\nqF7ea8ECOOmkkChmzFCiEJGGy8w+cPfCVOvpDu5qWrAglCjy8uCtt5QoRKRpULKohvnzQ6LYa69Q\nojjssGxHJCJSP5Qs0jR/fqh6UqIQkaYoV+6zyGnxieKtt3QZrIg0PSpZpPDPf4aqp+bNlShEpOlS\nskjiscfguOOgbdtQ9aREISJNlZJFArt2wY03wmWXwXe/C0VFShQi0rQpWVSybh2MGAEPPAA/+Qm8\n+ip07pztqEREsksN3HE++gjOOQdWrYJHHoHLL892RCIiuUEli8izz8JRR8G2bTBzZkgUU6aEfp2a\nNQuvU6ZkO0oRkexo8smitBR+8Qs4/3wYNCi0TxxxREgMY8eG3mTdw+vYsUoYItI0NflksWQJ3H8/\nXHFFuDT2oIPC/PHjKz4yFcL0+PH1HqKISNY1+TaLQw+FuXPhkEPC41FjVqxIvH5V80VEGrMmX7IA\n6Nu3YqKA8ByKRHLogXwiIvVGyaIKEydCmzYV57VpE+aLiDQ1ShZVGDMGJk+Gnj1DqaNnzzA9Zky2\nIxMRqX9Nvs0imTFjlBxEREAlCxERSYOShYiIpKRkISIiKSlZiIhISkoWIiKSkpKFiIiklNFkYWYj\nzGyRmS0xs3EJlk8ysznR8KmZfR237FIzWxwNl2YyThERSS5j91mYWR7wEHAqUAzMMrPp7v5xbB13\nvzFu/euBYdH4vsAEoBBw4INo2w2ZildERKqWyZLFcGCJuy919x3AVOCcJOtfBDwdjZ8OvObu66ME\n8RowIoOxiohIEplMFl2BlXHTxdG8PZhZT6A38GZ1tjWzsWZWZGZFJSUldRK0iIjsKVcauEcDz7j7\n7ups5O6T3b3Q3Qu7dOmSodBERCSTyWIV0D1uuls0L5HRlFdBVXdbERHJsEwmi1lAXzPrbWYtCAlh\neuWVzKwf0BF4L272q8BpZtbRzDoCp0XzREQkCzJ2NZS77zKz6wgn+TzgEXdfYGZ3AkXuHksco4Gp\n7u5x2643s18SEg7Ane6+PlOxiohIchZ3jm7QCgsLvaioKNthiIg0KGb2gbsXplovVxq4RUQkhylZ\niIhISkoWIiKSkpKFiIikpGQhIiIpKVmIiEhKShYiIpKSkoWIiKSkZCEiIikpWYiISEpKFiIikpKS\nhYiIpKRkISIiKTX5ZDFlCvTqBc2ahdcpU7IdkYhI7snY8ywagilTYOxY2LIlTC9fHqYBxozJXlwi\nIrmmSZcsxo8vTxQxW7aE+SIiUq5JJ4sVK6o3X0SkqWrSyaJHj+rNFxFpqpp0spg4Edq0qTivTZsw\nX0REyjXpZDFmDEyeDD17gll4nTxZjdsiIpU16auhICQGJQcRkeSadMlCRETSo2QhIiIpKVmIiEhK\nShYiIpKSkoWIiKRk7p7tGOqEmZUAy5Os0hn4qp7CqS7FVjOKrWYUW8001th6unuXVCs1mmSRipkV\nuXthtuNIRLHVjGKrGcVWM009NlVDiYhISkoWIiKSUlNKFpOzHUASiq1mFFvNKLaaadKxNZk2CxER\nqbmmVLIQEZEaUrIQEZGUGn2yMLMRZrbIzJaY2bhsx1OZmS0zs4/MbI6ZFWU5lkfMbK2ZzY+bt6+Z\nvWZmi6PXjjkU2x1mtio6dnPM7IwsxNXdzGaY2cdmtsDMbojmZ/24JYktF45bKzP7p5nNjWL7t2h+\nbzP7R/T/+icza5FDsT1qZp/HHbeh9R1bXIx5ZjbbzP43ms78cXP3RjsAecBnQB+gBTAXyM92XJVi\nXAZ0znYcUSzHAQXA/Lh5vwLGRePjgP+XQ7HdAdyS5WN2IFAQjbcDPgXyc+G4JYktF46bAXtH482B\nfwBHAtOA0dH83wPX5FBsjwLnZ/O4xcV4E/AU8L/RdMaPW2MvWQwHlrj7UnffAUwFzslyTDnL3WcC\n6yvNPgd4LBp/DPh+vQYVqSK2rHP31e7+YTT+LbAQ6EoOHLcksWWdB5uiyebR4MBJwDPR/Gwdt6pi\nywlm1g34HvCHaNqoh+PW2JNFV2Bl3HQxOfLPEseBv5rZB2Y2NtvBJLC/u6+Oxr8E9s9mMAlcZ2bz\nomqqrFSRxZhZL2AY4ZdoTh23SrFBDhy3qCplDrAWeI1QC/C1u++KVsna/2vl2Nw9dtwmRsdtkpm1\nzEZswAPArUBpNN2JejhujT1ZNATHuHsBMBK41syOy3ZAVfFQxs2ZX1jA74CDgaHAauD+bAViZnsD\nzwI/dfdv4pdl+7gliC0njpu773b3oUA3Qi1Av2zEkUjl2MxsIPAzQozfAfYF/rW+4zKzM4G17v5B\nfb93Y08Wq4DucdPdonk5w91XRa9rgecI/zS5ZI2ZHQgQva7Ncjxl3H1N9E9dCjxMlo6dmTUnnIyn\nuPv/RLNz4rglii1XjluMu38NzACOAjqYWexxz1n/f42LbURUrefuvh34I9k5bkcDZ5vZMkK1+knA\nb6iH49bYk8UsoG90pUALYDQwPcsxlTGztmbWLjYOnAbMT75VvZsOXBqNXwq8kMVYKoidjCPnkoVj\nF9UX/zew0N1/Hbco68etqthy5Lh1MbMO0Xhr4FRCm8oM4PxotWwdt0SxfRKX/I3QJlDvx83df+bu\n3dy9F+F89qa7j6E+jlu2W/UzPQBnEK4C+QwYn+14KsXWh3CF1lxgQbbjA54mVEvsJNR7/pBQH/oG\nsBh4Hdg3h2J7AvgImEc4OR+YhbiOIVQxzQPmRMMZuXDcksSWC8dtMDA7imE+cHs0vw/wT2AJ8Geg\nZQ7F9mZ03OYDTxJdMZWtATiB8quhMn7c1N2HiIik1NiroUREpA4oWYiISEpKFiIikpKShYiIpKRk\nISIiKSlZiKRgZrvjehqdY3XYe7GZ9YrvSVckV+2VehWRJm+rh64fRJoslSxEasjCs0h+ZeF5JP80\ns0Oi+b3M7M2ow7k3zKxHNH9/M3suek7CXDP7brSrPDN7OHp2wl+ju4Yxs59Ez6KYZ2ZTs/QxRQAl\nC5F0tK5UDXVh3LKN7j4I+C2hN1CA/wAec/fBwBTgwWj+g8Db7j6E8GyOBdH8vsBD7j4A+Bo4L5o/\nDhgW7efqTH04kXToDm6RFMxsk7vvnWD+MuAkd18addj3pbt3MrOvCF1o7Izmr3b3zmZWAnTz0BFd\nbB+9CF1g942m/xVo7u53mdkrwCbgeeB5L3/Ggki9U8lCpHa8ivHq2B43vpvytsTvAQ8RSiGz4noV\nFal3ShYitXNh3Ot70fjfCT2CAowB3onG3wCugbKH67Svaqdm1gzo7u4zCM9NaA/sUboRqS/6pSKS\nWuvoqWkxr7h77PLZjmY2j1A6uCiadz3wRzP7v0AJcHk0/wZgspn9kFCCuIbQk24iecCTUUIx4EEP\nz1YQyQq1WYjUUNRmUejuX2U7FpFMUzWUiIikpJKFiIikpJKFiIikpGQhIiIpKVmIiEhKShYiIpKS\nkoWIiKT0/wGJ5Uq78IlLNwAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "mdchyra1xrPu"
+      },
+      "source": [
+        "\n",
+        "このプロットでは以下を表します。\n",
+        "\n",
+        "- 点線は学習データセットの誤差と精度\n",
+        "- 実線は検証データセットの誤差と精度\n",
+        "\n",
+        "学習時の誤差が各エポックで*減少*し、精度が各エポックで*増加*することに注目してください。これは、勾配降下法による最適化を使うと、見られる動きです。エポックを反復するごとに、誤差が最小になるよう、パラメータを調整していきます。 \n",
+        "\n",
+        "しかし、検証データセットの誤差と精度には当てはまりません。約20エポックでピークに達したようです。これは過学習の兆候を示しています。モデルは、学習データセットに対して、未知のデータセットよりも優れた精度を示します。20エポックを超えると、モデルはテストデータに現れない、学習データセットに固有の表現を過度に最適化して学習してしまったようです。\n",
+        "\n",
+        "このケースでは、20回程度のエポックの後、単にトレーニングを中止することで、過学習を防げます。コールバックを使って、学習の自動停止をする方法もあります。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab_type": "code",
+        "id": "J7Y5l2UYfJxm",
+        "colab": {}
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": 0,
+      "outputs": []
     }
-   ],
-   "source": [
-    "plt.clf()   # clear figure\n",
-    "acc_values = history_dict['acc']\n",
-    "val_acc_values = history_dict['val_acc']\n",
-    "\n",
-    "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
-    "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",
-    "plt.title('Training and validation accuracy')\n",
-    "plt.xlabel('Epochs')\n",
-    "plt.ylabel('Accuracy')\n",
-    "plt.legend()\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "mdchyra1xrPu"
-   },
-   "source": [
-    "\n",
-    "このプロットでは以下を表します。\n",
-    "\n",
-    "- 点線は学習データセットの誤差と精度\n",
-    "- 実線は検証データセットの誤差と精度\n",
-    "\n",
-    "学習時の誤差が各エポックで*減少*し、精度が各エポックで*増加*することに注目してください。これは、勾配降下法による最適化を使うと、見られる動きです。エポックを反復するごとに、誤差が最小になるよう、パラメータを調整していきます。 \n",
-    "\n",
-    "しかし、検証データセットの誤差と精度には当てはまりません。約20エポックでピークに達したようです。これは過学習の兆候を示しています。モデルは、学習データセットに対して、未知のデータセットよりも優れた精度を示します。20エポックを超えると、モデルはテストデータに現れない、学習データセットに固有の表現を過度に最適化して学習してしまったようです。\n",
-    "\n",
-    "このケースでは、20回程度のエポックの後、単にトレーニングを中止することで、過学習を防げます。コールバックを使って、学習の自動停止をする方法もあります。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "J7Y5l2UYfJxm"
-   },
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "colab": {
-   "name": "映画情報サイトにあるレビューを識別する（その1）",
-   "provenance": [],
-   "version": "0.3.2"
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "accelerator": "GPU"
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  ]
 }


### PR DESCRIPTION
Downgrade numpy to 1.16.2 to avoid "ValueError: Object arrays cannot be loaded when allow_pickle=False" returned by imdb.load_data.
Reference: https://stackoverflow.com/questions/55824625/how-to-fix-object-arrays-cannot-be-loaded-when-allow-pickle-false-in-the-sketc
